### PR TITLE
Add the ability to run the site from a Virtual Machine (VM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,28 @@ Some early prototypes for a design pattern library.
 
 [http://alphagov.github.io/design-patterns/patterns/](http://alphagov.github.io/design-patterns/patterns/)
 
+## Set up
+
+To run the site inside a Virtual Machine (VM), you will need [Vagrant](http://www.vagrantup.com/) to create and manage the VM & [VirtualBox](https://www.virtualbox.org/) to run it.
+
+To create the VM, in the root of this repository, run:
+
+```
+vagrant up
+```
+
+To SSH into the newly started VM, run:
+
+```
+vagrant ssh
+```
+
+When logged into the VM, you will need to go to the project folder & run Bundler to install all the required RubyGems:
+
+```
+cd /design-patterns
+bundle
+```
 
 ## Installation
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,119 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "precise64"
+
+  # The url from where the 'config.vm.box' box will be fetched if it
+  # doesn't already exist on the user's system.
+  config.vm.box_url = 'http://files.vagrantup.com/precise64.box'
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  config.vm.network :forwarded_port, guest: 4000, host: 4000
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network :private_network, ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network :public_network
+
+  # If true, then any SSH connections made will enable agent forwarding.
+  # Default value: false
+  config.ssh.forward_agent = true
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder ".", "/design-patterns"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider :virtualbox do |vb|
+  #   # Don't boot with headless mode
+  #   vb.gui = true
+  #
+  #   # Use VBoxManage to customize the VM. For example to change memory:
+  #   vb.customize ["modifyvm", :id, "--memory", "1024"]
+  # end
+  #
+  # View the documentation for the provider you're using for more
+  # information on available options.
+
+  config.vm.provision "shell", path: "provision_design_patterns_vm.sh"
+  # Enable provisioning with Puppet stand alone.  Puppet manifests
+  # are contained in a directory path relative to this Vagrantfile.
+  # You will need to create the manifests directory and a manifest in
+  # the file base.pp in the manifests_path directory.
+  #
+  # An example Puppet manifest to provision the message of the day:
+  #
+  # # group { "puppet":
+  # #   ensure => "present",
+  # # }
+  # #
+  # # File { owner => 0, group => 0, mode => 0644 }
+  # #
+  # # file { '/etc/motd':
+  # #   content => "Welcome to your Vagrant-built virtual machine!
+  # #               Managed by Puppet.\n"
+  # # }
+  #
+  # config.vm.provision :puppet do |puppet|
+  #   puppet.manifests_path = "manifests"
+  #   puppet.manifest_file  = "site.pp"
+  # end
+
+  # Enable provisioning with chef solo, specifying a cookbooks path, roles
+  # path, and data_bags path (all relative to this Vagrantfile), and adding
+  # some recipes and/or roles.
+  #
+  # config.vm.provision :chef_solo do |chef|
+  #   chef.cookbooks_path = "../my-recipes/cookbooks"
+  #   chef.roles_path = "../my-recipes/roles"
+  #   chef.data_bags_path = "../my-recipes/data_bags"
+  #   chef.add_recipe "mysql"
+  #   chef.add_role "web"
+  #
+  #   # You may also specify custom JSON attributes:
+  #   chef.json = { :mysql_password => "foo" }
+  # end
+
+  # Enable provisioning with chef server, specifying the chef server URL,
+  # and the path to the validation key (relative to this Vagrantfile).
+  #
+  # The Opscode Platform uses HTTPS. Substitute your organization for
+  # ORGNAME in the URL and validation key.
+  #
+  # If you have your own Chef Server, use the appropriate URL, which may be
+  # HTTP instead of HTTPS depending on your configuration. Also change the
+  # validation key to validation.pem.
+  #
+  # config.vm.provision :chef_client do |chef|
+  #   chef.chef_server_url = "https://api.opscode.com/organizations/ORGNAME"
+  #   chef.validation_key_path = "ORGNAME-validator.pem"
+  # end
+  #
+  # If you're using the Opscode platform, your validator client is
+  # ORGNAME-validator, replacing ORGNAME with your organization name.
+  #
+  # If you have your own Chef Server, the default validation client name is
+  # chef-validator, unless you changed the configuration.
+  #
+  #   chef.validation_client_name = "ORGNAME-validator"
+end

--- a/provision_design_patterns_vm.sh
+++ b/provision_design_patterns_vm.sh
@@ -6,6 +6,8 @@ apt-get -y install ruby1.9.1-dev
 apt-get -y install make
 
 # Set language environment variables to UTF-8
+# There are non-ascii characters in our .md files
+# Kramdown (which Jekyll uses to parse Markdown) breaks without these set
 echo "Exporting environment variables"
 echo "export LANG=en_GB.utf8" >> /home/vagrant/.bashrc
 echo "export LC_ALL=en_GB.utf8" >> /home/vagrant/.bashrc

--- a/provision_design_patterns_vm.sh
+++ b/provision_design_patterns_vm.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+
+# Set up environment
+apt-get -y update
+apt-get -y install ruby1.9.1-dev
+apt-get -y install make
+
+# Set language environment variables to UTF-8
+echo "Exporting environment variables"
+echo "export LANG=en_GB.utf8" >> /home/vagrant/.bashrc
+echo "export LC_ALL=en_GB.utf8" >> /home/vagrant/.bashrc
+source ~/.bashrc
+
+# Set up application
+gem install bundler
+gem install sass
+cd /design-patterns
+bundle

--- a/provision_design_patterns_vm.sh
+++ b/provision_design_patterns_vm.sh
@@ -16,5 +16,3 @@ source ~/.bashrc
 # Set up application
 gem install bundler
 gem install sass
-cd /design-patterns
-bundle


### PR DESCRIPTION
Includes a default Vagrantfile with settings for running the Jekyll site & a script to set up the Ubuntu Virtual Machine (VM) and the Jekyll site.
