### PR TITLE
Proposal: new structure for example pages

### DIFF
--- a/_includes/layouts/_head.html
+++ b/_includes/layouts/_head.html
@@ -1,4 +1,11 @@
+{% if page.custom-css %}
 <!--[if gt IE 8]><!--><link href="{{ site.baseurl}}/assets/stylesheets/{{ page.custom-css }}/{{ page.custom-css }}.css"  rel="stylesheet" type="text/css"><!--<![endif]-->
 <!--[if IE 6]><link href="{{ site.baseurl}}/assets/stylesheets/{{ page.custom-css }}/{{ page.custom-css }}-ie6.css" rel="stylesheet" type="text/css" /><![endif]-->
 <!--[if IE 7]><link href="{{ site.baseurl}}/assets/stylesheets/{{ page.custom-css }}/{{ page.custom-css }}-ie7.css" rel="stylesheet" type="text/css" /><![endif]-->
 <!--[if IE 8]><link href="{{ site.baseurl}}/assets/stylesheets/{{ page.custom-css }}/{{ page.custom-css }}-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
+{% else %}
+<!--[if gt IE 8]><!--><link href="{{ site.baseurl}}/assets/stylesheets/base.css"  rel="stylesheet" type="text/css"><!--<![endif]-->
+<!--[if IE 6]><link href="{{ site.baseurl}}/assets/stylesheets/base-ie6.css" rel="stylesheet" type="text/css" /><![endif]-->
+<!--[if IE 7]><link href="{{ site.baseurl}}/assets/stylesheets/base-ie7.css" rel="stylesheet" type="text/css" /><![endif]-->
+<!--[if IE 8]><link href="{{ site.baseurl}}/assets/stylesheets/base-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
+{% endif %}

--- a/_includes/layouts/_head.html
+++ b/_includes/layouts/_head.html
@@ -1,4 +1,4 @@
-<!--[if gt IE 8]><!--><link href="{{ site.baseurl}}/assets/stylesheets/base.css"  rel="stylesheet" type="text/css"><!--<![endif]-->
-<!--[if IE 6]><link href="{{ site.baseurl}}/assets/stylesheets/base-ie6.css" rel="stylesheet" type="text/css" /><![endif]-->
-<!--[if IE 7]><link href="{{ site.baseurl}}/assets/stylesheets/base-ie7.css" rel="stylesheet" type="text/css" /><![endif]-->
-<!--[if IE 8]><link href="{{ site.baseurl}}/assets/stylesheets/base-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
+<!--[if gt IE 8]><!--><link href="{{ site.baseurl}}/assets/stylesheets/{{ page.custom-css }}/{{ page.custom-css }}.css"  rel="stylesheet" type="text/css"><!--<![endif]-->
+<!--[if IE 6]><link href="{{ site.baseurl}}/assets/stylesheets/{{ page.custom-css }}/{{ page.custom-css }}-ie6.css" rel="stylesheet" type="text/css" /><![endif]-->
+<!--[if IE 7]><link href="{{ site.baseurl}}/assets/stylesheets/{{ page.custom-css }}/{{ page.custom-css }}-ie7.css" rel="stylesheet" type="text/css" /><![endif]-->
+<!--[if IE 8]><link href="{{ site.baseurl}}/assets/stylesheets/{{ page.custom-css }}/{{ page.custom-css }}-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->

--- a/_layouts/template-example-sample.html
+++ b/_layouts/template-example-sample.html
@@ -1,0 +1,11 @@
+---
+layout: default
+service-title: "Design guide examples"
+document-type: Guide
+header-class: class="with-proposition"
+has-proposition: true
+---
+
+<main class="main gov-uk">
+  {{ content }}
+</main>

--- a/_layouts/template-example.html
+++ b/_layouts/template-example.html
@@ -4,6 +4,7 @@ service-title: "Design guide examples"
 document-type: Guide
 header-class: class="with-proposition"
 has-proposition: true
+custom-css: 'example'
 ---
 
 <main class="main gov-uk">

--- a/assets/sass/example-grids/example-grids-ie6.scss
+++ b/assets/sass/example-grids/example-grids-ie6.scss
@@ -1,0 +1,6 @@
+// BASE STYLESHEET FOR IE 6 COMPILER
+
+$is-ie: true;
+$ie-version: 6;
+
+@import "example-grids.scss";

--- a/assets/sass/example-grids/example-grids-ie7.scss
+++ b/assets/sass/example-grids/example-grids-ie7.scss
@@ -1,0 +1,6 @@
+// BASE STYLESHEET FOR IE 7 COMPILER
+
+$is-ie: true;
+$ie-version: 7;
+
+@import "example-grids.scss";

--- a/assets/sass/example-grids/example-grids-ie8.scss
+++ b/assets/sass/example-grids/example-grids-ie8.scss
@@ -1,0 +1,6 @@
+// BASE STYLESHEET FOR IE 8 COMPILER
+
+$is-ie: true;
+$ie-version: 8;
+
+@import "example-grids.scss";

--- a/assets/sass/example-grids/example-grids.scss
+++ b/assets/sass/example-grids/example-grids.scss
@@ -1,0 +1,46 @@
+//
+// Design Guide example
+//
+/* 
+  GOV.UK front end toolkit
+
+  Sass mixins and helpers for responsive design, x-browser compatibility and colour palettes
+*/
+
+@import "../govuk_frontend_toolkit/stylesheets/colours";
+@import "../govuk_frontend_toolkit/stylesheets/css3";
+@import "../govuk_frontend_toolkit/stylesheets/shims";
+@import "../govuk_frontend_toolkit/stylesheets/typography";
+
+@import "../govuk_frontend_toolkit/stylesheets/design-patterns/alpha-beta";
+@import "../govuk_frontend_toolkit/stylesheets/design-patterns/buttons";
+
+/*
+  Styles used to construct the page
+*/
+
+// Import helper vars and styles
+@import "../govuk-helper/vars";
+
+// Page styles
+@import "../design-patterns/_alpha-beta";
+@import "../design-patterns/_breadcrumb";
+
+// Content wrapper
+@import "../govuk-helper/_main_wrapper";
+
+// Grids
+@import "../govuk-helper/_grid_base.scss";
+@import "../govuk-helper/_grid_wrapper";
+@import "../govuk-helper/_grid_2_3";
+@import "../govuk-helper/_grid_1_3";
+@import "../govuk-helper/_grid_1_2";
+@import "../govuk-helper/_grid_1_4";
+
+// Typography
+@import "../govuk-helper/_typography_base";
+@import "../govuk-helper/_typography_general";
+@import "../govuk-helper/_typography_headings";
+
+// Display
+@import "../govuk-helper/_grid_highlights";

--- a/assets/sass/example-typography/example-typography-ie6.scss
+++ b/assets/sass/example-typography/example-typography-ie6.scss
@@ -1,0 +1,6 @@
+// BASE STYLESHEET FOR IE 6 COMPILER
+
+$is-ie: true;
+$ie-version: 6;
+
+@import "example-typography.scss";

--- a/assets/sass/example-typography/example-typography-ie7.scss
+++ b/assets/sass/example-typography/example-typography-ie7.scss
@@ -1,0 +1,6 @@
+// BASE STYLESHEET FOR IE 7 COMPILER
+
+$is-ie: true;
+$ie-version: 7;
+
+@import "example-typography.scss";

--- a/assets/sass/example-typography/example-typography-ie8.scss
+++ b/assets/sass/example-typography/example-typography-ie8.scss
@@ -1,0 +1,6 @@
+// BASE STYLESHEET FOR IE 8 COMPILER
+
+$is-ie: true;
+$ie-version: 8;
+
+@import "example-typography.scss";

--- a/assets/sass/example-typography/example-typography.scss
+++ b/assets/sass/example-typography/example-typography.scss
@@ -1,0 +1,42 @@
+//
+// Design Guide example
+//
+/* 
+  GOV.UK front end toolkit
+
+  Sass mixins and helpers for responsive design, x-browser compatibility and colour palettes
+*/
+
+@import "../govuk_frontend_toolkit/stylesheets/colours";
+@import "../govuk_frontend_toolkit/stylesheets/css3";
+@import "../govuk_frontend_toolkit/stylesheets/shims";
+@import "../govuk_frontend_toolkit/stylesheets/typography";
+
+@import "../govuk_frontend_toolkit/stylesheets/design-patterns/alpha-beta";
+@import "../govuk_frontend_toolkit/stylesheets/design-patterns/buttons";
+
+/*
+  Styles used to construct the page
+*/
+
+// Import helper vars and styles
+@import "../govuk-helper/vars";
+
+// Page styles
+@import "../design-patterns/_alpha-beta";
+@import "../design-patterns/_breadcrumb";
+
+// Content wrapper
+@import "../govuk-helper/_main_wrapper";
+
+// Grids
+@import "../govuk-helper/_grid_base.scss";
+@import "../govuk-helper/_grid_wrapper";
+
+// Typography
+@import "../govuk-helper/_typography_base";
+@import "../govuk-helper/_typography_general";
+@import "../govuk-helper/_typography_headings";
+
+// Content
+@import "../govuk-helper/_lists";

--- a/assets/sass/example/example-ie6.scss
+++ b/assets/sass/example/example-ie6.scss
@@ -1,0 +1,6 @@
+// BASE STYLESHEET FOR IE 6 COMPILER
+
+$is-ie: true;
+$ie-version: 6;
+
+@import "example.scss";

--- a/assets/sass/example/example-ie7.scss
+++ b/assets/sass/example/example-ie7.scss
@@ -1,0 +1,6 @@
+// BASE STYLESHEET FOR IE 7 COMPILER
+
+$is-ie: true;
+$ie-version: 7;
+
+@import "example.scss";

--- a/assets/sass/example/example-ie8.scss
+++ b/assets/sass/example/example-ie8.scss
@@ -1,0 +1,6 @@
+// BASE STYLESHEET FOR IE 8 COMPILER
+
+$is-ie: true;
+$ie-version: 8;
+
+@import "example.scss";

--- a/assets/sass/example/example.scss
+++ b/assets/sass/example/example.scss
@@ -1,0 +1,38 @@
+//
+// Design Guide example
+//
+// GOV.UK front end toolkit
+// Sass mixins and helpers for responsive design, x-browser compatibility and colour palettes
+@import "../govuk_frontend_toolkit/stylesheets/colours";
+@import "../govuk_frontend_toolkit/stylesheets/conditionals";
+@import "../govuk_frontend_toolkit/stylesheets/css3";
+@import "../govuk_frontend_toolkit/stylesheets/device-pixels";
+@import "../govuk_frontend_toolkit/stylesheets/measurements";
+@import "../govuk_frontend_toolkit/stylesheets/shims";
+@import "../govuk_frontend_toolkit/stylesheets/typography";
+
+@import "../govuk_frontend_toolkit/stylesheets/design-patterns/alpha-beta";
+@import "../govuk_frontend_toolkit/stylesheets/design-patterns/buttons";
+
+// GOV.UK helper (requires the GOV.UK frontend toolkit)
+// A couple of helper files to set basic styling 
+// - typography, grid layout, form elements and spacing
+
+// Import helper vars and styles
+@import "govuk-helper/vars";
+@import "govuk-helper/main";
+
+// Import design patterns
+@import "design-patterns/address-finder";
+@import "design-patterns/alpha-beta";
+@import "design-patterns/breadcrumb";
+@import "design-patterns/buttons";
+@import "design-patterns/date-of-birth";
+@import "design-patterns/forms";
+@import "design-patterns/phase-block";
+@import "design-patterns/progress-indicator";
+@import "design-patterns/progressive-disclosure";
+
+// Example styles, no need to include in your project
+@import "example/example";
+

--- a/assets/sass/govuk-helper/_colours.scss
+++ b/assets/sass/govuk-helper/_colours.scss
@@ -1,0 +1,3 @@
+.text-secondary {
+  color: $secondary-text-colour;
+}

--- a/assets/sass/govuk-helper/_forms.scss
+++ b/assets/sass/govuk-helper/_forms.scss
@@ -1,0 +1,75 @@
+form {
+  margin: 0;
+}
+
+button,
+input,
+select,
+textarea {
+  font-size: 100%;
+  margin: 0;
+  vertical-align: baseline;
+  *vertical-align: middle;
+}
+
+button,
+input {
+    line-height: normal;
+}
+
+textarea {
+  overflow: auto;
+  vertical-align: top;
+}
+
+input[type="text"],
+input[type="email"],
+input[type="date"],
+input[type="datetime"],
+input[type="datetime-local"],
+input[type="email"],
+input[type="month"],
+input[type="number"],
+input[type="search"],
+input[type="tel"],
+input[type="time"],
+input[type="url"],
+input[type="week"],
+select[size],
+textarea {
+  padding: 2px 4px;
+  background-color: #FFFFFF;
+  border: 2px inset;
+  @include ie-lte(8) {
+    border: 1px inset $border-colour; 
+  }
+  font-size: 1em;
+  
+  // Disable webkit appearance and remove rounded corners
+  -webkit-appearance: none;
+  border-radius: 0;
+}
+
+textarea {
+  min-height: 10em;
+  height: auto;
+}
+
+.form-control {
+  min-width: 96%;
+  @include media(tablet) {
+    min-width: 18em;
+  }
+}
+
+.form-group {
+  margin-bottom: $gutter-half;
+  @include media(tablet) {
+    margin-bottom: $gutter;
+  }
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 5px;
+}

--- a/assets/sass/govuk-helper/_grid_1_2.scss
+++ b/assets/sass/govuk-helper/_grid_1_2.scss
@@ -1,0 +1,6 @@
+.grid-1-2 {
+  width: 100%;
+  @include media(tablet) {
+    width: 50%;
+  }
+}

--- a/assets/sass/govuk-helper/_grid_1_3.scss
+++ b/assets/sass/govuk-helper/_grid_1_3.scss
@@ -1,0 +1,6 @@
+.grid-1-3 {
+  width: 100%;
+  @include media(tablet) {
+    width: 33.333333333%;
+  }
+}

--- a/assets/sass/govuk-helper/_grid_1_4.scss
+++ b/assets/sass/govuk-helper/_grid_1_4.scss
@@ -1,0 +1,6 @@
+.grid-1-4 {
+  width: 100%;
+  @include media(tablet) {
+    width: 25%;
+  }
+}

--- a/assets/sass/govuk-helper/_grid_2_3.scss
+++ b/assets/sass/govuk-helper/_grid_2_3.scss
@@ -1,0 +1,6 @@
+.grid-2-3 {
+  width: 100%;
+  @include media(tablet) {
+    width: 66.666666667%;
+  }
+}

--- a/assets/sass/govuk-helper/_grid_3_4.scss
+++ b/assets/sass/govuk-helper/_grid_3_4.scss
@@ -1,0 +1,6 @@
+.grid-3-4 {
+  width: 100%;
+  @include media(tablet) {
+    width: 75%;
+  }
+}

--- a/assets/sass/govuk-helper/_grid_base.scss
+++ b/assets/sass/govuk-helper/_grid_base.scss
@@ -1,0 +1,11 @@
+// Grid units take 100% width, unless a .grid-width class is applied
+.grid {
+  float: left;
+  width: 100%;
+}
+
+.grid .inner-block {
+  @include media(tablet) {
+    padding: 0 $gutter-half;
+  }
+}

--- a/assets/sass/govuk-helper/_grid_highlights.scss
+++ b/assets/sass/govuk-helper/_grid_highlights.scss
@@ -1,0 +1,14 @@
+.example-highlight-grid {
+  .grid-wrapper {
+    background:  $grey-2;
+  }
+
+  .grid {
+    background: $grey-4;
+  }
+
+  .grid .is-inner-block-highlight {
+    background: $grey-3;
+    width: 100%;
+  }
+}

--- a/assets/sass/govuk-helper/_grid_wrapper.scss
+++ b/assets/sass/govuk-helper/_grid_wrapper.scss
@@ -1,0 +1,8 @@
+// Wrap grid layout
+.grid-wrapper {
+  @extend %contain-floats;
+  padding: 0 $gutter-half;
+  @include media(tablet) {
+    padding: 0 $gutter-half;
+  }
+}

--- a/assets/sass/govuk-helper/_grids.scss
+++ b/assets/sass/govuk-helper/_grids.scss
@@ -1,0 +1,35 @@
+// Grid unit widths
+.grid-1-4 {
+  width: 100%;
+  @include media(tablet) {
+    width: 25%;
+  }
+}
+
+.grid-1-3 {
+  width: 100%;
+  @include media(tablet) {
+    width: 33.333333333%;
+  }
+}
+
+.grid-1-2 {
+  width: 100%;
+  @include media(tablet) {
+    width: 50%;
+  }
+}
+
+.grid-2-3 {
+  width: 100%;
+  @include media(tablet) {
+    width: 66.666666667%;
+  }
+}
+
+.grid-3-4 {
+  width: 100%;
+  @include media(tablet) {
+    width: 75%;
+  }
+}

--- a/assets/sass/govuk-helper/_helpers.scss
+++ b/assets/sass/govuk-helper/_helpers.scss
@@ -1,0 +1,11 @@
+.is-space {
+  margin-bottom: $gutter;
+}
+
+.is-double-space {
+  margin-bottom: $gutter*2;
+}
+
+.cf {
+  @extend %contain-floats;
+}

--- a/assets/sass/govuk-helper/_lists.scss
+++ b/assets/sass/govuk-helper/_lists.scss
@@ -1,0 +1,30 @@
+dl,
+menu,
+ol,
+ul {
+  margin: 0;
+}
+
+dd {
+  margin-left: 0;
+}
+
+menu,
+ol,
+ul {
+  margin-top: 5px;
+  margin-bottom: 20px;
+  padding: 0 0 0 20px;
+}
+
+ul {
+  list-style-type: disc;
+}
+ol {
+  list-style-type: decimal;
+}
+
+ul li,
+ol li {
+  margin-bottom: 5px;
+}

--- a/assets/sass/govuk-helper/_main_wrapper.scss
+++ b/assets/sass/govuk-helper/_main_wrapper.scss
@@ -1,0 +1,5 @@
+.main {
+  max-width: 1020px;
+  width: auto;
+  margin: 0 auto 90px;
+}

--- a/assets/sass/govuk-helper/_typography_base.scss
+++ b/assets/sass/govuk-helper/_typography_base.scss
@@ -1,0 +1,6 @@
+// Increase default font size to 19px
+body {
+  @include core-19;
+  -webkit-font-smoothing: antialiased;
+}
+

--- a/assets/sass/govuk-helper/_typography_data.scss
+++ b/assets/sass/govuk-helper/_typography_data.scss
@@ -1,0 +1,13 @@
+.data-80 {
+  @include bold-80;
+  line-height: 0.4;
+}
+
+.data-48 {
+  @include bold-48;
+  line-height: 0.2;
+}
+
+.data p {
+  @include bold-16;
+}

--- a/assets/sass/govuk-helper/_typography_general.scss
+++ b/assets/sass/govuk-helper/_typography_general.scss
@@ -1,0 +1,15 @@
+// Set a max-width for text blocks
+// Less than 75 characters per line of text
+.text {
+  max-width: 30em;
+}
+
+p, 
+pre {
+  margin-top: 5px;
+  margin-bottom: 20px;
+}
+
+.intro {
+  margin-bottom: $gutter;
+}

--- a/assets/sass/govuk-helper/_typography_headings.scss
+++ b/assets/sass/govuk-helper/_typography_headings.scss
@@ -1,0 +1,48 @@
+h1,
+.heading-48 {
+  @include bold-48();
+  margin-top: $gutter-half;
+  margin-bottom: $gutter;
+  @include media(tablet) {
+    margin-top: $gutter;
+    margin-bottom: $gutter*2;
+  }
+  span,
+  .document-type {
+    display: block;
+    @include core-27();
+    color: $secondary-text-colour;
+  }
+}
+
+h2,
+.heading-36 {
+  @include bold-36();
+  margin-top: 25px;
+  margin-bottom: 10px;
+  @include media(tablet) {
+    margin-top: 45px;
+    margin-bottom: 20px;
+  }
+}
+
+h3,
+.heading-24 {
+  @include bold-24();
+  margin-top: 25px;
+  margin-bottom: 10px;
+  @include media(tablet) {
+    margin-top: 45px;
+    margin-bottom: 20px;
+  }
+}
+
+h4,
+.heading-19 {
+  @include bold-19();
+  margin-top: 10px;
+  margin-bottom: 5px;
+  @include media(tablet) {
+    margin-top: 20px;
+  }
+}


### PR DESCRIPTION
This proposal is for the SCSS structure used for example pages to be built around the readability of the resulting CSS. This includes favouring readability over any optimisations that would normally be applied to reduce duplication.

To comply, the resulting CSS should meet these requirements:
1. The CSS for a page shouldn't contain CSS not used on the page
2. documentation about the way CSS is applied should be in comments in the CSS, nowhere else
3. SCSS partials should be single-purpose to satisfy point 1. & so their @import statements explain what they do

Note: point 1. is to help developers so when they inspect the CSS to see what is needed to make that pattern they aren't confused by code used somewhere else.
