### PR TITLE
Update button guidance

### DIFF
--- a/assets/govuk_template/stylesheets/govuk-template.css
+++ b/assets/govuk_template/stylesheets/govuk-template.css
@@ -135,7 +135,7 @@ fieldset {
 
 a,
 a:visited {
-  color: #2e3191; }
+  color: #005ea5; }
 
 a:hover {
   color: #2e8aca; }

--- a/assets/sass/govuk-helper/_buttons.scss
+++ b/assets/sass/govuk-helper/_buttons.scss
@@ -1,9 +1,32 @@
 .button {
 	@include button ($green);
 	margin: 0 $gutter-half $gutter-half 0;
+	padding: 10px 10px 5px 10px;
 	vertical-align: top;
 }
+.button:focus {
+	outline: 3px solid $yellow;
+}
 
-.button-secondary {
-	@include button ($grey-3);
+.button-link {
+	// Remove browser default button styles
+	background: none;
+	border: none;
+	// Override webkit default button styles
+	-webkit-font-smoothing: antialiased;
+	// Match .button styles
+	display: inline-block;
+	color: $link-colour;
+	line-height: 1.25;
+	text-decoration: underline;
+	cursor: pointer;
+	margin: 0 $gutter-half $gutter-half 0;
+	padding: 10px 10px 5px 10px;
+	vertical-align: top;
+}
+.button-link:hover {
+	color: $link-hover-colour;
+}
+.button-link:focus {
+	outline: 3px solid $yellow;
 }

--- a/assets/sass/govuk-helper/_buttons.scss
+++ b/assets/sass/govuk-helper/_buttons.scss
@@ -1,9 +1,31 @@
 .button {
 	@include button ($green);
 	margin: 0 $gutter-half $gutter-half 0;
+	padding: 10px 10px 5px 10px;
 	vertical-align: top;
 }
-
-.button-secondary {
-	@include button ($grey-3);
+.button:focus {
+	outline: 3px solid $yellow;
 }
+
+.button-link {
+	// Remove browser default button styles
+	background: none;
+	border: none;
+	// Set line height to match .button styles
+	line-height: 1.25;
+	// Set button colour to link colour
+	color: $link-colour;
+	text-decoration: underline;
+	// Set cursor to match button cursor
+	cursor: pointer;
+	padding: 10px 10px 5px 10px;
+	vertical-align: top;
+}
+.button-link:hover {
+	color: $link-hover-colour;
+}
+.button-link:focus {
+	outline: 3px solid $yellow;
+}
+

--- a/assets/sass/govuk-helper/_buttons.scss
+++ b/assets/sass/govuk-helper/_buttons.scss
@@ -12,13 +12,15 @@
 	// Remove browser default button styles
 	background: none;
 	border: none;
-	// Set line height to match .button styles
-	line-height: 1.25;
-	// Set button colour to link colour
+	// Override webkit default button styles
+	-webkit-font-smoothing: antialiased;
+	// Match .button styles
+	display: inline-block;
 	color: $link-colour;
+	line-height: 1.25;
 	text-decoration: underline;
-	// Set cursor to match button cursor
 	cursor: pointer;
+	margin: 0 $gutter-half $gutter-half 0;
 	padding: 10px 10px 5px 10px;
 	vertical-align: top;
 }
@@ -28,4 +30,3 @@
 .button-link:focus {
 	outline: 3px solid $yellow;
 }
-

--- a/assets/stylesheets/base-ie6.css
+++ b/assets/stylesheets/base-ie6.css
@@ -507,18 +507,21 @@ Example usage:
 .govuk .button-link {
   background: none;
   border: none;
-  line-height: 1.25;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
   color: #005ea5;
+  line-height: 1.25;
   text-decoration: underline;
   cursor: pointer;
+  margin: 0 15px 15px 0;
   padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
-/* line 25, ../sass/govuk-helper/_buttons.scss */
+/* line 27, ../sass/govuk-helper/_buttons.scss */
 .govuk .button-link:hover {
   color: #2e8aca;
 }
-/* line 28, ../sass/govuk-helper/_buttons.scss */
+/* line 30, ../sass/govuk-helper/_buttons.scss */
 .govuk .button-link:focus {
   outline: 3px solid #ffbf47;
 }

--- a/assets/stylesheets/base-ie6.css
+++ b/assets/stylesheets/base-ie6.css
@@ -425,6 +425,7 @@ Example usage:
   cursor: pointer;
   color: white;
   margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
 /* line 51, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
@@ -499,100 +500,27 @@ Example usage:
   filter: none;
 }
 /* line 7, ../sass/govuk-helper/_buttons.scss */
-.govuk .button-secondary {
-  background-color: #dee0e2;
-  position: relative;
-  display: -moz-inline-stack;
-  display: inline-block;
-  zoom: 1;
-  display: inline;
-  padding: 0.35em 0.5em 0.15em 0.5em;
+.govuk .button:focus {
+  outline: 3px solid #ffbf47;
+}
+/* line 11, ../sass/govuk-helper/_buttons.scss */
+.govuk .button-link {
+  background: none;
   border: none;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-  border-radius: 0;
-  -webkit-appearance: none;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-  font-size: 1em;
   line-height: 1.25;
-  text-decoration: none;
-  -webkit-font-smoothing: antialiased;
+  color: #005ea5;
+  text-decoration: underline;
   cursor: pointer;
-  color: #0b0c0c;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top;
 }
-/* line 51, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:visited {
-  background-color: #dee0e2;
+/* line 25, ../sass/govuk-helper/_buttons.scss */
+.govuk .button-link:hover {
+  color: #2e8aca;
 }
-/* line 55, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus {
-  background-color: #d0d3d6;
-}
-/* line 58, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active {
-  top: 2px;
-  -webkit-box-shadow: 0 0 0 #dee0e2;
-  -moz-box-shadow: 0 0 0 #dee0e2;
-  box-shadow: 0 0 0 #dee0e2;
-}
-/* line 66, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled, .govuk .button-secondary[disabled="disabled"], .govuk .button-secondary[disabled] {
-  zoom: 1;
-  filter: alpha(opacity=50);
-  opacity: 0.5;
-}
-/* line 68, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:hover, .govuk .button-secondary[disabled="disabled"]:hover, .govuk .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 72, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:active, .govuk .button-secondary[disabled="disabled"]:active, .govuk .button-secondary[disabled]:active {
-  top: 0;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-}
-/* line 93, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus, .govuk .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 100, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:before {
-  content: "";
-  height: 110%;
-  width: 100%;
-  display: block;
-  background: transparent;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-/* line 110, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-  top: auto;
-  height: 100%;
-}
-/* line 123, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[rel="external"]:after {
-  display: none;
-  content: none;
-  margin-left: 0;
-  margin-right: 0;
-}
-/* line 134, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type="submit"], .govuk .button-secondary[type="reset"], .govuk .button-secondary[type="button"] {
-  filter: chroma(color=black);
-}
-/* line 138, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type=submit].button {
-  filter: none;
+/* line 28, ../sass/govuk-helper/_buttons.scss */
+.govuk .button-link:focus {
+  outline: 3px solid #ffbf47;
 }
 /* line 1, ../sass/govuk-helper/_colours.scss */
 .govuk .text-secondary {

--- a/assets/stylesheets/base-ie6.css
+++ b/assets/stylesheets/base-ie6.css
@@ -425,6 +425,7 @@ Example usage:
   cursor: pointer;
   color: white;
   margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
 /* line 51, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
@@ -499,100 +500,30 @@ Example usage:
   filter: none;
 }
 /* line 7, ../sass/govuk-helper/_buttons.scss */
-.govuk .button-secondary {
-  background-color: #dee0e2;
-  position: relative;
-  display: -moz-inline-stack;
-  display: inline-block;
-  zoom: 1;
-  display: inline;
-  padding: 0.35em 0.5em 0.15em 0.5em;
+.govuk .button:focus {
+  outline: 3px solid #ffbf47;
+}
+/* line 11, ../sass/govuk-helper/_buttons.scss */
+.govuk .button-link {
+  background: none;
   border: none;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-  border-radius: 0;
-  -webkit-appearance: none;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-  font-size: 1em;
-  line-height: 1.25;
-  text-decoration: none;
   -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  color: #005ea5;
+  line-height: 1.25;
+  text-decoration: underline;
   cursor: pointer;
-  color: #0b0c0c;
+  margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top;
 }
-/* line 51, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:visited {
-  background-color: #dee0e2;
+/* line 27, ../sass/govuk-helper/_buttons.scss */
+.govuk .button-link:hover {
+  color: #2e8aca;
 }
-/* line 55, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus {
-  background-color: #d0d3d6;
-}
-/* line 58, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active {
-  top: 2px;
-  -webkit-box-shadow: 0 0 0 #dee0e2;
-  -moz-box-shadow: 0 0 0 #dee0e2;
-  box-shadow: 0 0 0 #dee0e2;
-}
-/* line 66, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled, .govuk .button-secondary[disabled="disabled"], .govuk .button-secondary[disabled] {
-  zoom: 1;
-  filter: alpha(opacity=50);
-  opacity: 0.5;
-}
-/* line 68, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:hover, .govuk .button-secondary[disabled="disabled"]:hover, .govuk .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 72, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:active, .govuk .button-secondary[disabled="disabled"]:active, .govuk .button-secondary[disabled]:active {
-  top: 0;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-}
-/* line 93, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus, .govuk .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 100, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:before {
-  content: "";
-  height: 110%;
-  width: 100%;
-  display: block;
-  background: transparent;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-/* line 110, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-  top: auto;
-  height: 100%;
-}
-/* line 123, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[rel="external"]:after {
-  display: none;
-  content: none;
-  margin-left: 0;
-  margin-right: 0;
-}
-/* line 134, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type="submit"], .govuk .button-secondary[type="reset"], .govuk .button-secondary[type="button"] {
-  filter: chroma(color=black);
-}
-/* line 138, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type=submit].button {
-  filter: none;
+/* line 30, ../sass/govuk-helper/_buttons.scss */
+.govuk .button-link:focus {
+  outline: 3px solid #ffbf47;
 }
 /* line 1, ../sass/govuk-helper/_colours.scss */
 .govuk .text-secondary {

--- a/assets/stylesheets/base-ie7.css
+++ b/assets/stylesheets/base-ie7.css
@@ -522,18 +522,21 @@ Example usage:
 .govuk .button-link {
   background: none;
   border: none;
-  line-height: 1.25;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
   color: #005ea5;
+  line-height: 1.25;
   text-decoration: underline;
   cursor: pointer;
+  margin: 0 15px 15px 0;
   padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
-/* line 25, ../sass/govuk-helper/_buttons.scss */
+/* line 27, ../sass/govuk-helper/_buttons.scss */
 .govuk .button-link:hover {
   color: #2e8aca;
 }
-/* line 28, ../sass/govuk-helper/_buttons.scss */
+/* line 30, ../sass/govuk-helper/_buttons.scss */
 .govuk .button-link:focus {
   outline: 3px solid #ffbf47;
 }

--- a/assets/stylesheets/base-ie7.css
+++ b/assets/stylesheets/base-ie7.css
@@ -442,6 +442,7 @@ Example usage:
   cursor: pointer;
   color: white;
   margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
 /* line 51, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
@@ -514,98 +515,30 @@ Example usage:
   filter: none;
 }
 /* line 7, ../sass/govuk-helper/_buttons.scss */
-.govuk .button-secondary {
-  background-color: #dee0e2;
-  position: relative;
-  display: -moz-inline-stack;
-  display: inline-block;
-  zoom: 1;
-  display: inline;
-  padding: 0.35em 0.5em 0.15em 0.5em;
+.govuk .button:focus {
+  outline: 3px solid #ffbf47;
+}
+/* line 11, ../sass/govuk-helper/_buttons.scss */
+.govuk .button-link {
+  background: none;
   border: none;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-  border-radius: 0;
-  -webkit-appearance: none;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-  font-size: 1em;
-  line-height: 1.25;
-  text-decoration: none;
   -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  color: #005ea5;
+  line-height: 1.25;
+  text-decoration: underline;
   cursor: pointer;
-  color: #0b0c0c;
+  margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top;
 }
-/* line 51, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:visited {
-  background-color: #dee0e2;
+/* line 27, ../sass/govuk-helper/_buttons.scss */
+.govuk .button-link:hover {
+  color: #2e8aca;
 }
-/* line 55, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus {
-  background-color: #d0d3d6;
-}
-/* line 58, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active {
-  top: 2px;
-  -webkit-box-shadow: 0 0 0 #dee0e2;
-  -moz-box-shadow: 0 0 0 #dee0e2;
-  box-shadow: 0 0 0 #dee0e2;
-}
-/* line 66, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled, .govuk .button-secondary[disabled="disabled"], .govuk .button-secondary[disabled] {
-  zoom: 1;
-  filter: alpha(opacity=50);
-  opacity: 0.5;
-}
-/* line 68, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:hover, .govuk .button-secondary[disabled="disabled"]:hover, .govuk .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 72, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:active, .govuk .button-secondary[disabled="disabled"]:active, .govuk .button-secondary[disabled]:active {
-  top: 0;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-}
-/* line 93, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus, .govuk .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 100, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:before {
-  content: "";
-  height: 110%;
-  width: 100%;
-  display: block;
-  background: transparent;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-/* line 110, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-}
-/* line 123, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[rel="external"]:after {
-  display: none;
-  content: none;
-  margin-left: 0;
-  margin-right: 0;
-}
-/* line 134, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type="submit"], .govuk .button-secondary[type="reset"], .govuk .button-secondary[type="button"] {
-  filter: chroma(color=black);
-}
-/* line 138, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type=submit].button {
-  filter: none;
+/* line 30, ../sass/govuk-helper/_buttons.scss */
+.govuk .button-link:focus {
+  outline: 3px solid #ffbf47;
 }
 /* line 1, ../sass/govuk-helper/_colours.scss */
 .govuk .text-secondary {

--- a/assets/stylesheets/base-ie7.css
+++ b/assets/stylesheets/base-ie7.css
@@ -442,6 +442,7 @@ Example usage:
   cursor: pointer;
   color: white;
   margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
 /* line 51, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
@@ -514,98 +515,27 @@ Example usage:
   filter: none;
 }
 /* line 7, ../sass/govuk-helper/_buttons.scss */
-.govuk .button-secondary {
-  background-color: #dee0e2;
-  position: relative;
-  display: -moz-inline-stack;
-  display: inline-block;
-  zoom: 1;
-  display: inline;
-  padding: 0.35em 0.5em 0.15em 0.5em;
+.govuk .button:focus {
+  outline: 3px solid #ffbf47;
+}
+/* line 11, ../sass/govuk-helper/_buttons.scss */
+.govuk .button-link {
+  background: none;
   border: none;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-  border-radius: 0;
-  -webkit-appearance: none;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-  font-size: 1em;
   line-height: 1.25;
-  text-decoration: none;
-  -webkit-font-smoothing: antialiased;
+  color: #005ea5;
+  text-decoration: underline;
   cursor: pointer;
-  color: #0b0c0c;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top;
 }
-/* line 51, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:visited {
-  background-color: #dee0e2;
+/* line 25, ../sass/govuk-helper/_buttons.scss */
+.govuk .button-link:hover {
+  color: #2e8aca;
 }
-/* line 55, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus {
-  background-color: #d0d3d6;
-}
-/* line 58, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active {
-  top: 2px;
-  -webkit-box-shadow: 0 0 0 #dee0e2;
-  -moz-box-shadow: 0 0 0 #dee0e2;
-  box-shadow: 0 0 0 #dee0e2;
-}
-/* line 66, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled, .govuk .button-secondary[disabled="disabled"], .govuk .button-secondary[disabled] {
-  zoom: 1;
-  filter: alpha(opacity=50);
-  opacity: 0.5;
-}
-/* line 68, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:hover, .govuk .button-secondary[disabled="disabled"]:hover, .govuk .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 72, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:active, .govuk .button-secondary[disabled="disabled"]:active, .govuk .button-secondary[disabled]:active {
-  top: 0;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-}
-/* line 93, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus, .govuk .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 100, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:before {
-  content: "";
-  height: 110%;
-  width: 100%;
-  display: block;
-  background: transparent;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-/* line 110, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-}
-/* line 123, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[rel="external"]:after {
-  display: none;
-  content: none;
-  margin-left: 0;
-  margin-right: 0;
-}
-/* line 134, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type="submit"], .govuk .button-secondary[type="reset"], .govuk .button-secondary[type="button"] {
-  filter: chroma(color=black);
-}
-/* line 138, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type=submit].button {
-  filter: none;
+/* line 28, ../sass/govuk-helper/_buttons.scss */
+.govuk .button-link:focus {
+  outline: 3px solid #ffbf47;
 }
 /* line 1, ../sass/govuk-helper/_colours.scss */
 .govuk .text-secondary {

--- a/assets/stylesheets/base-ie8.css
+++ b/assets/stylesheets/base-ie8.css
@@ -425,6 +425,7 @@ Example usage:
   cursor: pointer;
   color: white;
   margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
 /* line 51, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
@@ -497,96 +498,27 @@ Example usage:
   filter: none;
 }
 /* line 7, ../sass/govuk-helper/_buttons.scss */
-.govuk .button-secondary {
-  background-color: #dee0e2;
-  position: relative;
-  display: -moz-inline-stack;
-  display: inline-block;
-  padding: 0.35em 0.5em 0.15em 0.5em;
+.govuk .button:focus {
+  outline: 3px solid #ffbf47;
+}
+/* line 11, ../sass/govuk-helper/_buttons.scss */
+.govuk .button-link {
+  background: none;
   border: none;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-  border-radius: 0;
-  -webkit-appearance: none;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-  font-size: 1em;
   line-height: 1.25;
-  text-decoration: none;
-  -webkit-font-smoothing: antialiased;
+  color: #005ea5;
+  text-decoration: underline;
   cursor: pointer;
-  color: #0b0c0c;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top;
 }
-/* line 51, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:visited {
-  background-color: #dee0e2;
+/* line 25, ../sass/govuk-helper/_buttons.scss */
+.govuk .button-link:hover {
+  color: #2e8aca;
 }
-/* line 55, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus {
-  background-color: #d0d3d6;
-}
-/* line 58, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active {
-  top: 2px;
-  -webkit-box-shadow: 0 0 0 #dee0e2;
-  -moz-box-shadow: 0 0 0 #dee0e2;
-  box-shadow: 0 0 0 #dee0e2;
-}
-/* line 66, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled, .govuk .button-secondary[disabled="disabled"], .govuk .button-secondary[disabled] {
-  zoom: 1;
-  filter: alpha(opacity=50);
-  opacity: 0.5;
-}
-/* line 68, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:hover, .govuk .button-secondary[disabled="disabled"]:hover, .govuk .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 72, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:active, .govuk .button-secondary[disabled="disabled"]:active, .govuk .button-secondary[disabled]:active {
-  top: 0;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-}
-/* line 93, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus, .govuk .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 100, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:before {
-  content: "";
-  height: 110%;
-  width: 100%;
-  display: block;
-  background: transparent;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-/* line 110, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-}
-/* line 123, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[rel="external"]:after {
-  display: none;
-  content: none;
-  margin-left: 0;
-  margin-right: 0;
-}
-/* line 134, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type="submit"], .govuk .button-secondary[type="reset"], .govuk .button-secondary[type="button"] {
-  filter: chroma(color=black);
-}
-/* line 138, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type=submit].button {
-  filter: none;
+/* line 28, ../sass/govuk-helper/_buttons.scss */
+.govuk .button-link:focus {
+  outline: 3px solid #ffbf47;
 }
 /* line 1, ../sass/govuk-helper/_colours.scss */
 .govuk .text-secondary {

--- a/assets/stylesheets/base-ie8.css
+++ b/assets/stylesheets/base-ie8.css
@@ -425,6 +425,7 @@ Example usage:
   cursor: pointer;
   color: white;
   margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
 /* line 51, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
@@ -497,96 +498,30 @@ Example usage:
   filter: none;
 }
 /* line 7, ../sass/govuk-helper/_buttons.scss */
-.govuk .button-secondary {
-  background-color: #dee0e2;
-  position: relative;
-  display: -moz-inline-stack;
-  display: inline-block;
-  padding: 0.35em 0.5em 0.15em 0.5em;
+.govuk .button:focus {
+  outline: 3px solid #ffbf47;
+}
+/* line 11, ../sass/govuk-helper/_buttons.scss */
+.govuk .button-link {
+  background: none;
   border: none;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-  border-radius: 0;
-  -webkit-appearance: none;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-  font-size: 1em;
-  line-height: 1.25;
-  text-decoration: none;
   -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  color: #005ea5;
+  line-height: 1.25;
+  text-decoration: underline;
   cursor: pointer;
-  color: #0b0c0c;
+  margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top;
 }
-/* line 51, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:visited {
-  background-color: #dee0e2;
+/* line 27, ../sass/govuk-helper/_buttons.scss */
+.govuk .button-link:hover {
+  color: #2e8aca;
 }
-/* line 55, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus {
-  background-color: #d0d3d6;
-}
-/* line 58, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active {
-  top: 2px;
-  -webkit-box-shadow: 0 0 0 #dee0e2;
-  -moz-box-shadow: 0 0 0 #dee0e2;
-  box-shadow: 0 0 0 #dee0e2;
-}
-/* line 66, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled, .govuk .button-secondary[disabled="disabled"], .govuk .button-secondary[disabled] {
-  zoom: 1;
-  filter: alpha(opacity=50);
-  opacity: 0.5;
-}
-/* line 68, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:hover, .govuk .button-secondary[disabled="disabled"]:hover, .govuk .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 72, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:active, .govuk .button-secondary[disabled="disabled"]:active, .govuk .button-secondary[disabled]:active {
-  top: 0;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-}
-/* line 93, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus, .govuk .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 100, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:before {
-  content: "";
-  height: 110%;
-  width: 100%;
-  display: block;
-  background: transparent;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-/* line 110, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-}
-/* line 123, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[rel="external"]:after {
-  display: none;
-  content: none;
-  margin-left: 0;
-  margin-right: 0;
-}
-/* line 134, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type="submit"], .govuk .button-secondary[type="reset"], .govuk .button-secondary[type="button"] {
-  filter: chroma(color=black);
-}
-/* line 138, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type=submit].button {
-  filter: none;
+/* line 30, ../sass/govuk-helper/_buttons.scss */
+.govuk .button-link:focus {
+  outline: 3px solid #ffbf47;
 }
 /* line 1, ../sass/govuk-helper/_colours.scss */
 .govuk .text-secondary {

--- a/assets/stylesheets/base-ie8.css
+++ b/assets/stylesheets/base-ie8.css
@@ -505,18 +505,21 @@ Example usage:
 .govuk .button-link {
   background: none;
   border: none;
-  line-height: 1.25;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
   color: #005ea5;
+  line-height: 1.25;
   text-decoration: underline;
   cursor: pointer;
+  margin: 0 15px 15px 0;
   padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
-/* line 25, ../sass/govuk-helper/_buttons.scss */
+/* line 27, ../sass/govuk-helper/_buttons.scss */
 .govuk .button-link:hover {
   color: #2e8aca;
 }
-/* line 28, ../sass/govuk-helper/_buttons.scss */
+/* line 30, ../sass/govuk-helper/_buttons.scss */
 .govuk .button-link:focus {
   outline: 3px solid #ffbf47;
 }

--- a/assets/stylesheets/base.css
+++ b/assets/stylesheets/base.css
@@ -547,18 +547,21 @@ Example usage:
 .govuk .button-link {
   background: none;
   border: none;
-  line-height: 1.25;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
   color: #005ea5;
+  line-height: 1.25;
   text-decoration: underline;
   cursor: pointer;
+  margin: 0 15px 15px 0;
   padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
-/* line 25, ../sass/govuk-helper/_buttons.scss */
+/* line 27, ../sass/govuk-helper/_buttons.scss */
 .govuk .button-link:hover {
   color: #2e8aca;
 }
-/* line 28, ../sass/govuk-helper/_buttons.scss */
+/* line 30, ../sass/govuk-helper/_buttons.scss */
 .govuk .button-link:focus {
   outline: 3px solid #ffbf47;
 }

--- a/assets/stylesheets/base.css
+++ b/assets/stylesheets/base.css
@@ -476,6 +476,7 @@ Example usage:
   cursor: pointer;
   color: white;
   margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
 /* line 51, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
@@ -539,86 +540,27 @@ Example usage:
   margin-right: 0;
 }
 /* line 7, ../sass/govuk-helper/_buttons.scss */
-.govuk .button-secondary {
-  background-color: #dee0e2;
-  position: relative;
-  display: -moz-inline-stack;
-  display: inline-block;
-  padding: 0.35em 0.5em 0.15em 0.5em;
+.govuk .button:focus {
+  outline: 3px solid #ffbf47;
+}
+/* line 11, ../sass/govuk-helper/_buttons.scss */
+.govuk .button-link {
+  background: none;
   border: none;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-  border-radius: 0;
-  -webkit-appearance: none;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  font-size: 1em;
   line-height: 1.25;
-  text-decoration: none;
-  -webkit-font-smoothing: antialiased;
+  color: #005ea5;
+  text-decoration: underline;
   cursor: pointer;
-  color: #0b0c0c;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top;
 }
-/* line 51, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:visited {
-  background-color: #dee0e2;
+/* line 25, ../sass/govuk-helper/_buttons.scss */
+.govuk .button-link:hover {
+  color: #2e8aca;
 }
-/* line 55, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus {
-  background-color: #d0d3d6;
-}
-/* line 58, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active {
-  top: 2px;
-  -webkit-box-shadow: 0 0 0 #dee0e2;
-  -moz-box-shadow: 0 0 0 #dee0e2;
-  box-shadow: 0 0 0 #dee0e2;
-}
-/* line 66, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled, .govuk .button-secondary[disabled="disabled"], .govuk .button-secondary[disabled] {
-  zoom: 1;
-  filter: alpha(opacity=50);
-  opacity: 0.5;
-}
-/* line 68, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:hover, .govuk .button-secondary[disabled="disabled"]:hover, .govuk .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 72, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:active, .govuk .button-secondary[disabled="disabled"]:active, .govuk .button-secondary[disabled]:active {
-  top: 0;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-}
-/* line 93, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus, .govuk .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 100, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:before {
-  content: "";
-  height: 110%;
-  width: 100%;
-  display: block;
-  background: transparent;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-/* line 110, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-}
-/* line 123, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[rel="external"]:after {
-  display: none;
-  content: none;
-  margin-left: 0;
-  margin-right: 0;
+/* line 28, ../sass/govuk-helper/_buttons.scss */
+.govuk .button-link:focus {
+  outline: 3px solid #ffbf47;
 }
 /* line 1, ../sass/govuk-helper/_colours.scss */
 .govuk .text-secondary {

--- a/assets/stylesheets/base.css
+++ b/assets/stylesheets/base.css
@@ -476,6 +476,7 @@ Example usage:
   cursor: pointer;
   color: white;
   margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
 /* line 51, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
@@ -539,86 +540,30 @@ Example usage:
   margin-right: 0;
 }
 /* line 7, ../sass/govuk-helper/_buttons.scss */
-.govuk .button-secondary {
-  background-color: #dee0e2;
-  position: relative;
-  display: -moz-inline-stack;
-  display: inline-block;
-  padding: 0.35em 0.5em 0.15em 0.5em;
+.govuk .button:focus {
+  outline: 3px solid #ffbf47;
+}
+/* line 11, ../sass/govuk-helper/_buttons.scss */
+.govuk .button-link {
+  background: none;
   border: none;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-  border-radius: 0;
-  -webkit-appearance: none;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  font-size: 1em;
-  line-height: 1.25;
-  text-decoration: none;
   -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  color: #005ea5;
+  line-height: 1.25;
+  text-decoration: underline;
   cursor: pointer;
-  color: #0b0c0c;
+  margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top;
 }
-/* line 51, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:visited {
-  background-color: #dee0e2;
+/* line 27, ../sass/govuk-helper/_buttons.scss */
+.govuk .button-link:hover {
+  color: #2e8aca;
 }
-/* line 55, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus {
-  background-color: #d0d3d6;
-}
-/* line 58, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active {
-  top: 2px;
-  -webkit-box-shadow: 0 0 0 #dee0e2;
-  -moz-box-shadow: 0 0 0 #dee0e2;
-  box-shadow: 0 0 0 #dee0e2;
-}
-/* line 66, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled, .govuk .button-secondary[disabled="disabled"], .govuk .button-secondary[disabled] {
-  zoom: 1;
-  filter: alpha(opacity=50);
-  opacity: 0.5;
-}
-/* line 68, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:hover, .govuk .button-secondary[disabled="disabled"]:hover, .govuk .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 72, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:active, .govuk .button-secondary[disabled="disabled"]:active, .govuk .button-secondary[disabled]:active {
-  top: 0;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-}
-/* line 93, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus, .govuk .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 100, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:before {
-  content: "";
-  height: 110%;
-  width: 100%;
-  display: block;
-  background: transparent;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-/* line 110, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-}
-/* line 123, ../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[rel="external"]:after {
-  display: none;
-  content: none;
-  margin-left: 0;
-  margin-right: 0;
+/* line 30, ../sass/govuk-helper/_buttons.scss */
+.govuk .button-link:focus {
+  outline: 3px solid #ffbf47;
 }
 /* line 1, ../sass/govuk-helper/_colours.scss */
 .govuk .text-secondary {

--- a/assets/stylesheets/example-form/example-form.css
+++ b/assets/stylesheets/example-form/example-form.css
@@ -9,9 +9,11 @@
 @-ms-viewport {
   width: device-width;
 }
+
 @-o-viewport {
   width: device-width;
 }
+
 /* Usage:
    @include inline-block
 
@@ -28,13 +30,8 @@
    }
 
 */
-<<<<<<< HEAD
 /* line 49, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/_shims.scss */
 .govuk .cf:after, .govuk .grid-wrapper:after, .phase-block:after {
-=======
-/* line 49, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/_shims.scss */
-.phase-block:after, .grid-wrapper:after {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
   content: "";
   display: block;
   clear: both;
@@ -44,23 +41,27 @@
   font-family: GDS-Logo;
   src: local("HelveticaNeue"), local("Helvetica Neue"), local("Arial"), local("Helvetica");
 }
+
 @-ms-viewport {
   width: device-width;
 }
+
 @-o-viewport {
   width: device-width;
 }
+
 @font-face {
   font-family: GDS-Logo;
   src: local("HelveticaNeue"), local("Helvetica Neue"), local("Arial"), local("Helvetica");
 }
+
 @-ms-viewport {
   width: device-width;
 }
+
 @-o-viewport {
   width: device-width;
 }
-<<<<<<< HEAD
 
 /* Cross-browser shims
 
@@ -97,8 +98,6 @@
   clear: both;
 }
 
-=======
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
 /* Cross-browser shims
 
   Ways of normalising properties across browsers.
@@ -106,9 +105,11 @@
 @-ms-viewport {
   width: device-width;
 }
+
 @-o-viewport {
   width: device-width;
 }
+
 /* Usage:
    @include inline-block
 
@@ -125,16 +126,23 @@
    }
 
 */
-<<<<<<< HEAD
 /* line 49, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/_shims.scss */
 .govuk .cf:after, .govuk .grid-wrapper:after, .phase-block:after {
-=======
-/* line 49, /Users/timpaul/code/gds/design-patterns/assets/sass/../govuk_frontend_toolkit/stylesheets/design-patterns/../_shims.scss */
-.phase-block:after, .grid-wrapper:after {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
   content: "";
   display: block;
   clear: both;
+}
+
+/* CSS 3 Mixins
+
+  Add them as you need them. This should let us manage vendor prefixes in one place.
+ */
+@-ms-viewport {
+  width: device-width;
+}
+
+@-o-viewport {
+  width: device-width;
 }
 
 /*
@@ -156,111 +164,8 @@ Example usage:
 }
 
 */
-<<<<<<< HEAD
 /* line 1, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_main-wrapper.scss */
 .main {
-=======
-/* line 1, ../../sass/design-patterns/_alpha-beta.scss */
-.phase-banner {
-  padding: 8px 0;
-  background-color: #d53880;
-}
-/* line 14, /Users/timpaul/code/gds/design-patterns/assets/sass/../govuk_frontend_toolkit/stylesheets/design-patterns/_alpha-beta.scss */
-.phase-banner p {
-  max-width: 960px;
-  margin: 0 auto;
-  padding: 0 15px;
-  color: #0b0c0c;
-  font-family: "nta", Arial, sans-serif;
-  font-size: 16px;
-  line-height: 1.25;
-  font-weight: 300;
-  text-transform: none;
-}
-@media (max-width: 640px) {
-  /* line 14, /Users/timpaul/code/gds/design-patterns/assets/sass/../govuk_frontend_toolkit/stylesheets/design-patterns/_alpha-beta.scss */
-  .phase-banner p {
-    font-size: 14px;
-    line-height: 1.14286;
-  }
-}
-/* line 23, /Users/timpaul/code/gds/design-patterns/assets/sass/../govuk_frontend_toolkit/stylesheets/design-patterns/_alpha-beta.scss */
-.phase-banner a, .phase-banner a:link, .phase-banner a:visited, .phase-banner a:active {
-  color: #0b0c0c;
-}
-/* line 27, /Users/timpaul/code/gds/design-patterns/assets/sass/../govuk_frontend_toolkit/stylesheets/design-patterns/_alpha-beta.scss */
-.phase-banner a:hover {
-  color: #0b0c0c;
-}
-
-/* line 1, ../../sass/design-patterns/_phase-block.scss */
-.phase-block {
-  display: inline !important;
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-/* line 9, ../../sass/design-patterns/_phase-block.scss */
-.phase-block .alpha,
-.phase-block .beta {
-  display: inline;
-  vertical-align: middle;
-  float: none;
-}
-/* line 16, ../../sass/design-patterns/_phase-block.scss */
-.phase-block .alpha {
-  display: -moz-inline-stack;
-  display: inline-block;
-  background-color: #d53880;
-  color: #fff;
-  font-family: "nta", Arial, sans-serif;
-  font-size: 16px;
-  line-height: 1.25;
-  font-weight: 300;
-  text-transform: none;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  text-decoration: none;
-  margin: 3px 10px 0 5px;
-  padding: 2px 5px 0;
-}
-@media (max-width: 640px) {
-  /* line 16, ../../sass/design-patterns/_phase-block.scss */
-  .phase-block .alpha {
-    font-size: 14px;
-    line-height: 1.14286;
-  }
-}
-/* line 20, ../../sass/design-patterns/_phase-block.scss */
-.phase-block .beta {
-  display: -moz-inline-stack;
-  display: inline-block;
-  background-color: #f47738;
-  color: #fff;
-  font-family: "nta", Arial, sans-serif;
-  font-size: 16px;
-  line-height: 1.25;
-  font-weight: 300;
-  text-transform: none;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  text-decoration: none;
-  margin: 3px 10px 0 5px;
-  padding: 2px 5px 0;
-}
-@media (max-width: 640px) {
-  /* line 20, ../../sass/design-patterns/_phase-block.scss */
-  .phase-block .beta {
-    font-size: 14px;
-    line-height: 1.14286;
-  }
-}
-
-/* line 1, ../../sass/design-patterns/_breadcrumb.scss */
-.breadcrumb {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
   max-width: 1020px;
   width: auto;
   margin: 0 auto 90px;
@@ -287,16 +192,9 @@ Example usage:
     line-height: 1.25;
   }
 }
-<<<<<<< HEAD
 /* line 2, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_typography-general.scss */
 .govuk p,
 .govuk pre {
-=======
-
-/* line 1, ../../sass/govuk-helper/_typography-general.scss */
-p,
-pre {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
   margin-top: 5px;
   margin-bottom: 20px;
 }
@@ -540,7 +438,6 @@ pre {
     width: 75%;
   }
 }
-<<<<<<< HEAD
 /* line 4, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_grid-highlights.scss */
 .govuk .example-highlight-grid .grid-wrapper {
   background: #bfc1c3;
@@ -553,113 +450,6 @@ pre {
 .govuk .example-highlight-grid .grid .is-inner-block-highlight {
   background: #dee0e2;
   width: 100%;
-=======
-
-/* line 1, ../../sass/govuk-helper/_forms.scss */
-form {
-  margin: 0;
-}
-
-/* line 5, ../../sass/govuk-helper/_forms.scss */
-button,
-input,
-select,
-textarea {
-  font-size: 100%;
-  margin: 0;
-  vertical-align: baseline;
-  *vertical-align: middle;
-}
-
-/* line 15, ../../sass/govuk-helper/_forms.scss */
-legend {
-  padding-left: 0;
-}
-
-/* line 19, ../../sass/govuk-helper/_forms.scss */
-button,
-input {
-  line-height: normal;
-}
-
-/* line 24, ../../sass/govuk-helper/_forms.scss */
-input[type="text"],
-input[type="email"],
-input[type="date"],
-input[type="datetime"],
-input[type="datetime-local"],
-input[type="email"],
-input[type="month"],
-input[type="number"],
-input[type="search"],
-input[type="tel"],
-input[type="time"],
-input[type="url"],
-input[type="week"],
-select[size],
-textarea {
-  font-size: 1em;
-  padding: 4px;
-  background-color: white;
-  border: 1px solid #bfc1c3;
-  -webkit-appearance: none;
-  border-radius: 0;
-}
-
-/* line 50, ../../sass/govuk-helper/_forms.scss */
-textarea {
-  overflow: auto;
-  vertical-align: top;
-  min-height: 190px;
-  height: auto;
-}
-
-/* line 57, ../../sass/govuk-helper/_forms.scss */
-.form-group {
-  margin-bottom: 15px;
-}
-@media (min-width: 641px) {
-  /* line 57, ../../sass/govuk-helper/_forms.scss */
-  .form-group {
-    margin-bottom: 30px;
-  }
-}
-
-/* line 64, ../../sass/govuk-helper/_forms.scss */
-.form-group label {
-  display: block;
-  margin-bottom: 5px;
-}
-
-/* line 69, ../../sass/govuk-helper/_forms.scss */
-.form-control {
-  width: 96%;
-}
-@media (min-width: 641px) {
-  /* line 69, ../../sass/govuk-helper/_forms.scss */
-  .form-control {
-    width: 350px;
-  }
-}
-
-/* line 76, ../../sass/govuk-helper/_forms.scss */
-.hint {
-  display: block;
-  color: #6f777b;
-  font-family: "nta", Arial, sans-serif;
-  font-size: 16px;
-  line-height: 1.25;
-  font-weight: 300;
-  text-transform: none;
-  margin-top: 8px;
-}
-@media (max-width: 640px) {
-  /* line 76, ../../sass/govuk-helper/_forms.scss */
-  .hint {
-    font-size: 14px;
-    line-height: 1.14286;
-  }
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
 }
 /* line 1, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
 .govuk .button {
@@ -669,9 +459,10 @@ textarea {
   display: inline-block;
   padding: 0.35em 0.5em 0.15em 0.5em;
   border: none;
-  -webkit-border-radius: 0.25em;
-  -moz-border-radius: 0.25em;
-  border-radius: 0.25em;
+  -webkit-border-radius: 0;
+  -moz-border-radius: 0;
+  border-radius: 0;
+  -webkit-appearance: none;
   -webkit-box-shadow: 0 2px 0 #00180c;
   -moz-box-shadow: 0 2px 0 #00180c;
   box-shadow: 0 2px 0 #00180c;
@@ -682,9 +473,9 @@ textarea {
   cursor: pointer;
   color: white;
   margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
-<<<<<<< HEAD
 /* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
 .govuk .button:visited {
   background-color: #006435;
@@ -695,35 +486,17 @@ textarea {
 }
 /* line 58, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
 .govuk .button:active {
-=======
-/* line 46, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button:visited {
-  background-color: #006435;
-}
-/* line 49, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button:hover, .button:focus {
-  background: #004b27;
-}
-/* line 53, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button:active {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
   top: 2px;
   -webkit-box-shadow: 0 0 0 #006435;
   -moz-box-shadow: 0 0 0 #006435;
   box-shadow: 0 0 0 #006435;
 }
-<<<<<<< HEAD
 /* line 66, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
 .govuk .button.disabled, .govuk .button[disabled="disabled"], .govuk .button[disabled] {
-=======
-/* line 59, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button.disabled, .button[disabled="disabled"], .button[disabled] {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
   zoom: 1;
   filter: alpha(opacity=50);
   opacity: 0.5;
 }
-<<<<<<< HEAD
 /* line 68, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
 .govuk .button.disabled:hover, .govuk .button[disabled="disabled"]:hover, .govuk .button[disabled]:hover {
   cursor: default;
@@ -731,35 +504,17 @@ textarea {
 }
 /* line 72, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
 .govuk .button.disabled:active, .govuk .button[disabled="disabled"]:active, .govuk .button[disabled]:active {
-=======
-/* line 63, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button.disabled:hover, .button[disabled="disabled"]:hover, .button[disabled]:hover {
-  cursor: default;
-  background-color: #006435;
-}
-/* line 67, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button.disabled:active, .button[disabled="disabled"]:active, .button[disabled]:active {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
   top: 0;
   -webkit-box-shadow: 0 2px 0 #00180c;
   -moz-box-shadow: 0 2px 0 #00180c;
   box-shadow: 0 2px 0 #00180c;
 }
-<<<<<<< HEAD
 /* line 86, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
 .govuk .button:hover, .govuk .button:focus, .govuk .button:visited {
   color: white;
 }
 /* line 100, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
 .govuk .button:before {
-=======
-/* line 79, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button:hover, .button:focus, .button:visited {
-  color: white;
-}
-/* line 95, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button:before {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
   content: "";
   height: 110%;
   width: 100%;
@@ -769,7 +524,6 @@ textarea {
   top: 0;
   left: 0;
 }
-<<<<<<< HEAD
 /* line 110, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
 .govuk .button:active:before {
   top: -10%;
@@ -777,147 +531,33 @@ textarea {
 }
 /* line 123, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
 .govuk .button[rel="external"]:after {
-=======
-/* line 105, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button:active:before {
-  top: -10%;
-  height: 120%;
-}
-/* line 118, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button[rel="external"]:after {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
   display: none;
   content: none;
   margin-left: 0;
   margin-right: 0;
 }
 /* line 7, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
-.govuk .button-secondary {
-  background-color: #dee0e2;
-  position: relative;
-  display: -moz-inline-stack;
-  display: inline-block;
-  padding: 0.35em 0.5em 0.15em 0.5em;
+.govuk .button:focus {
+  outline: 3px solid #ffbf47;
+}
+/* line 11, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link {
+  background: none;
   border: none;
-  -webkit-border-radius: 0.25em;
-  -moz-border-radius: 0.25em;
-  border-radius: 0.25em;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  font-size: 1em;
   line-height: 1.25;
-  text-decoration: none;
-  -webkit-font-smoothing: antialiased;
+  color: #005ea5;
+  text-decoration: underline;
   cursor: pointer;
-  color: #0b0c0c;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top;
 }
-<<<<<<< HEAD
-/* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:visited {
-  background-color: #dee0e2;
+/* line 25, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:hover {
+  color: #2e8aca;
 }
-/* line 55, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus {
-  background-color: #d0d3d6;
-}
-/* line 58, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active {
-=======
-/* line 46, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button-secondary:visited {
-  background-color: #dee0e2;
-}
-/* line 49, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button-secondary:hover, .button-secondary:focus {
-  background: #d0d3d6;
-}
-/* line 53, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button-secondary:active {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
-  top: 2px;
-  -webkit-box-shadow: 0 0 0 #dee0e2;
-  -moz-box-shadow: 0 0 0 #dee0e2;
-  box-shadow: 0 0 0 #dee0e2;
-}
-<<<<<<< HEAD
-/* line 66, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled, .govuk .button-secondary[disabled="disabled"], .govuk .button-secondary[disabled] {
-=======
-/* line 59, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button-secondary.disabled, .button-secondary[disabled="disabled"], .button-secondary[disabled] {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
-  zoom: 1;
-  filter: alpha(opacity=50);
-  opacity: 0.5;
-}
-<<<<<<< HEAD
-/* line 68, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:hover, .govuk .button-secondary[disabled="disabled"]:hover, .govuk .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 72, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:active, .govuk .button-secondary[disabled="disabled"]:active, .govuk .button-secondary[disabled]:active {
-=======
-/* line 63, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button-secondary.disabled:hover, .button-secondary[disabled="disabled"]:hover, .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 67, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button-secondary.disabled:active, .button-secondary[disabled="disabled"]:active, .button-secondary[disabled]:active {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
-  top: 0;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-}
-<<<<<<< HEAD
-/* line 93, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus, .govuk .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 100, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:before {
-=======
-/* line 86, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button-secondary:hover, .button-secondary:focus, .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 95, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button-secondary:before {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
-  content: "";
-  height: 110%;
-  width: 100%;
-  display: block;
-  background: transparent;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-<<<<<<< HEAD
-/* line 110, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-}
-/* line 123, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[rel="external"]:after {
-=======
-/* line 105, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-}
-/* line 118, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button-secondary[rel="external"]:after {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
-  display: none;
-  content: none;
-  margin-left: 0;
-  margin-right: 0;
+/* line 28, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:focus {
+  outline: 3px solid #ffbf47;
 }
 /* line 1, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_colours.scss */
 .govuk .text-secondary {
@@ -973,12 +613,16 @@ textarea {
   vertical-align: baseline;
   *vertical-align: middle;
 }
-/* line 16, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
+/* line 15, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
+.govuk legend {
+  padding-left: 0;
+}
+/* line 20, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
 .govuk button,
 .govuk input {
   line-height: normal;
 }
-/* line 34, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
+/* line 38, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
 .govuk input[type="text"],
 .govuk input[type="email"],
 .govuk input[type="date"],
@@ -1001,39 +645,39 @@ textarea {
   -webkit-appearance: none;
   border-radius: 0;
 }
-/* line 46, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
+/* line 50, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
 .govuk textarea {
   overflow: auto;
   vertical-align: top;
   min-height: 190px;
   height: auto;
 }
-/* line 53, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
+/* line 57, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
 .govuk .form-group {
   margin-bottom: 15px;
 }
 @media (min-width: 641px) {
-  /* line 53, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
+  /* line 57, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
   .govuk .form-group {
     margin-bottom: 30px;
   }
 }
-/* line 60, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
+/* line 64, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
 .govuk .form-group label {
   display: block;
   margin-bottom: 5px;
 }
-/* line 65, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
+/* line 69, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
 .govuk .form-control {
   width: 96%;
 }
 @media (min-width: 641px) {
-  /* line 65, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
+  /* line 69, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
   .govuk .form-control {
     width: 350px;
   }
 }
-/* line 72, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
+/* line 76, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
 .govuk .hint {
   display: block;
   color: #6f777b;
@@ -1045,7 +689,7 @@ textarea {
   margin-top: 8px;
 }
 @media (max-width: 640px) {
-  /* line 72, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
+  /* line 76, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
   .govuk .hint {
     font-size: 14px;
     line-height: 1.14286;

--- a/assets/stylesheets/example-form/example-form.css
+++ b/assets/stylesheets/example-form/example-form.css
@@ -544,18 +544,21 @@ Example usage:
 .govuk .button-link {
   background: none;
   border: none;
-  line-height: 1.25;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
   color: #005ea5;
+  line-height: 1.25;
   text-decoration: underline;
   cursor: pointer;
+  margin: 0 15px 15px 0;
   padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
-/* line 25, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+/* line 27, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
 .govuk .button-link:hover {
   color: #2e8aca;
 }
-/* line 28, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+/* line 30, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
 .govuk .button-link:focus {
   outline: 3px solid #ffbf47;
 }

--- a/assets/stylesheets/example-form/example-form.css
+++ b/assets/stylesheets/example-form/example-form.css
@@ -9,9 +9,11 @@
 @-ms-viewport {
   width: device-width;
 }
+
 @-o-viewport {
   width: device-width;
 }
+
 /* Usage:
    @include inline-block
 
@@ -28,13 +30,8 @@
    }
 
 */
-<<<<<<< HEAD
 /* line 49, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/_shims.scss */
 .govuk .cf:after, .govuk .grid-wrapper:after, .phase-block:after {
-=======
-/* line 49, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/_shims.scss */
-.phase-block:after, .grid-wrapper:after {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
   content: "";
   display: block;
   clear: both;
@@ -44,23 +41,27 @@
   font-family: GDS-Logo;
   src: local("HelveticaNeue"), local("Helvetica Neue"), local("Arial"), local("Helvetica");
 }
+
 @-ms-viewport {
   width: device-width;
 }
+
 @-o-viewport {
   width: device-width;
 }
+
 @font-face {
   font-family: GDS-Logo;
   src: local("HelveticaNeue"), local("Helvetica Neue"), local("Arial"), local("Helvetica");
 }
+
 @-ms-viewport {
   width: device-width;
 }
+
 @-o-viewport {
   width: device-width;
 }
-<<<<<<< HEAD
 
 /* Cross-browser shims
 
@@ -97,8 +98,6 @@
   clear: both;
 }
 
-=======
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
 /* Cross-browser shims
 
   Ways of normalising properties across browsers.
@@ -106,9 +105,11 @@
 @-ms-viewport {
   width: device-width;
 }
+
 @-o-viewport {
   width: device-width;
 }
+
 /* Usage:
    @include inline-block
 
@@ -125,16 +126,23 @@
    }
 
 */
-<<<<<<< HEAD
 /* line 49, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/_shims.scss */
 .govuk .cf:after, .govuk .grid-wrapper:after, .phase-block:after {
-=======
-/* line 49, /Users/timpaul/code/gds/design-patterns/assets/sass/../govuk_frontend_toolkit/stylesheets/design-patterns/../_shims.scss */
-.phase-block:after, .grid-wrapper:after {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
   content: "";
   display: block;
   clear: both;
+}
+
+/* CSS 3 Mixins
+
+  Add them as you need them. This should let us manage vendor prefixes in one place.
+ */
+@-ms-viewport {
+  width: device-width;
+}
+
+@-o-viewport {
+  width: device-width;
 }
 
 /*
@@ -156,111 +164,8 @@ Example usage:
 }
 
 */
-<<<<<<< HEAD
 /* line 1, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_main-wrapper.scss */
 .main {
-=======
-/* line 1, ../../sass/design-patterns/_alpha-beta.scss */
-.phase-banner {
-  padding: 8px 0;
-  background-color: #d53880;
-}
-/* line 14, /Users/timpaul/code/gds/design-patterns/assets/sass/../govuk_frontend_toolkit/stylesheets/design-patterns/_alpha-beta.scss */
-.phase-banner p {
-  max-width: 960px;
-  margin: 0 auto;
-  padding: 0 15px;
-  color: #0b0c0c;
-  font-family: "nta", Arial, sans-serif;
-  font-size: 16px;
-  line-height: 1.25;
-  font-weight: 300;
-  text-transform: none;
-}
-@media (max-width: 640px) {
-  /* line 14, /Users/timpaul/code/gds/design-patterns/assets/sass/../govuk_frontend_toolkit/stylesheets/design-patterns/_alpha-beta.scss */
-  .phase-banner p {
-    font-size: 14px;
-    line-height: 1.14286;
-  }
-}
-/* line 23, /Users/timpaul/code/gds/design-patterns/assets/sass/../govuk_frontend_toolkit/stylesheets/design-patterns/_alpha-beta.scss */
-.phase-banner a, .phase-banner a:link, .phase-banner a:visited, .phase-banner a:active {
-  color: #0b0c0c;
-}
-/* line 27, /Users/timpaul/code/gds/design-patterns/assets/sass/../govuk_frontend_toolkit/stylesheets/design-patterns/_alpha-beta.scss */
-.phase-banner a:hover {
-  color: #0b0c0c;
-}
-
-/* line 1, ../../sass/design-patterns/_phase-block.scss */
-.phase-block {
-  display: inline !important;
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-/* line 9, ../../sass/design-patterns/_phase-block.scss */
-.phase-block .alpha,
-.phase-block .beta {
-  display: inline;
-  vertical-align: middle;
-  float: none;
-}
-/* line 16, ../../sass/design-patterns/_phase-block.scss */
-.phase-block .alpha {
-  display: -moz-inline-stack;
-  display: inline-block;
-  background-color: #d53880;
-  color: #fff;
-  font-family: "nta", Arial, sans-serif;
-  font-size: 16px;
-  line-height: 1.25;
-  font-weight: 300;
-  text-transform: none;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  text-decoration: none;
-  margin: 3px 10px 0 5px;
-  padding: 2px 5px 0;
-}
-@media (max-width: 640px) {
-  /* line 16, ../../sass/design-patterns/_phase-block.scss */
-  .phase-block .alpha {
-    font-size: 14px;
-    line-height: 1.14286;
-  }
-}
-/* line 20, ../../sass/design-patterns/_phase-block.scss */
-.phase-block .beta {
-  display: -moz-inline-stack;
-  display: inline-block;
-  background-color: #f47738;
-  color: #fff;
-  font-family: "nta", Arial, sans-serif;
-  font-size: 16px;
-  line-height: 1.25;
-  font-weight: 300;
-  text-transform: none;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  text-decoration: none;
-  margin: 3px 10px 0 5px;
-  padding: 2px 5px 0;
-}
-@media (max-width: 640px) {
-  /* line 20, ../../sass/design-patterns/_phase-block.scss */
-  .phase-block .beta {
-    font-size: 14px;
-    line-height: 1.14286;
-  }
-}
-
-/* line 1, ../../sass/design-patterns/_breadcrumb.scss */
-.breadcrumb {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
   max-width: 1020px;
   width: auto;
   margin: 0 auto 90px;
@@ -287,16 +192,9 @@ Example usage:
     line-height: 1.25;
   }
 }
-<<<<<<< HEAD
 /* line 2, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_typography-general.scss */
 .govuk p,
 .govuk pre {
-=======
-
-/* line 1, ../../sass/govuk-helper/_typography-general.scss */
-p,
-pre {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
   margin-top: 5px;
   margin-bottom: 20px;
 }
@@ -540,7 +438,6 @@ pre {
     width: 75%;
   }
 }
-<<<<<<< HEAD
 /* line 4, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_grid-highlights.scss */
 .govuk .example-highlight-grid .grid-wrapper {
   background: #bfc1c3;
@@ -553,113 +450,6 @@ pre {
 .govuk .example-highlight-grid .grid .is-inner-block-highlight {
   background: #dee0e2;
   width: 100%;
-=======
-
-/* line 1, ../../sass/govuk-helper/_forms.scss */
-form {
-  margin: 0;
-}
-
-/* line 5, ../../sass/govuk-helper/_forms.scss */
-button,
-input,
-select,
-textarea {
-  font-size: 100%;
-  margin: 0;
-  vertical-align: baseline;
-  *vertical-align: middle;
-}
-
-/* line 15, ../../sass/govuk-helper/_forms.scss */
-legend {
-  padding-left: 0;
-}
-
-/* line 19, ../../sass/govuk-helper/_forms.scss */
-button,
-input {
-  line-height: normal;
-}
-
-/* line 24, ../../sass/govuk-helper/_forms.scss */
-input[type="text"],
-input[type="email"],
-input[type="date"],
-input[type="datetime"],
-input[type="datetime-local"],
-input[type="email"],
-input[type="month"],
-input[type="number"],
-input[type="search"],
-input[type="tel"],
-input[type="time"],
-input[type="url"],
-input[type="week"],
-select[size],
-textarea {
-  font-size: 1em;
-  padding: 4px;
-  background-color: white;
-  border: 1px solid #bfc1c3;
-  -webkit-appearance: none;
-  border-radius: 0;
-}
-
-/* line 50, ../../sass/govuk-helper/_forms.scss */
-textarea {
-  overflow: auto;
-  vertical-align: top;
-  min-height: 190px;
-  height: auto;
-}
-
-/* line 57, ../../sass/govuk-helper/_forms.scss */
-.form-group {
-  margin-bottom: 15px;
-}
-@media (min-width: 641px) {
-  /* line 57, ../../sass/govuk-helper/_forms.scss */
-  .form-group {
-    margin-bottom: 30px;
-  }
-}
-
-/* line 64, ../../sass/govuk-helper/_forms.scss */
-.form-group label {
-  display: block;
-  margin-bottom: 5px;
-}
-
-/* line 69, ../../sass/govuk-helper/_forms.scss */
-.form-control {
-  width: 96%;
-}
-@media (min-width: 641px) {
-  /* line 69, ../../sass/govuk-helper/_forms.scss */
-  .form-control {
-    width: 350px;
-  }
-}
-
-/* line 76, ../../sass/govuk-helper/_forms.scss */
-.hint {
-  display: block;
-  color: #6f777b;
-  font-family: "nta", Arial, sans-serif;
-  font-size: 16px;
-  line-height: 1.25;
-  font-weight: 300;
-  text-transform: none;
-  margin-top: 8px;
-}
-@media (max-width: 640px) {
-  /* line 76, ../../sass/govuk-helper/_forms.scss */
-  .hint {
-    font-size: 14px;
-    line-height: 1.14286;
-  }
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
 }
 /* line 1, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
 .govuk .button {
@@ -669,9 +459,10 @@ textarea {
   display: inline-block;
   padding: 0.35em 0.5em 0.15em 0.5em;
   border: none;
-  -webkit-border-radius: 0.25em;
-  -moz-border-radius: 0.25em;
-  border-radius: 0.25em;
+  -webkit-border-radius: 0;
+  -moz-border-radius: 0;
+  border-radius: 0;
+  -webkit-appearance: none;
   -webkit-box-shadow: 0 2px 0 #00180c;
   -moz-box-shadow: 0 2px 0 #00180c;
   box-shadow: 0 2px 0 #00180c;
@@ -682,9 +473,9 @@ textarea {
   cursor: pointer;
   color: white;
   margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
-<<<<<<< HEAD
 /* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
 .govuk .button:visited {
   background-color: #006435;
@@ -695,35 +486,17 @@ textarea {
 }
 /* line 58, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
 .govuk .button:active {
-=======
-/* line 46, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button:visited {
-  background-color: #006435;
-}
-/* line 49, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button:hover, .button:focus {
-  background: #004b27;
-}
-/* line 53, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button:active {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
   top: 2px;
   -webkit-box-shadow: 0 0 0 #006435;
   -moz-box-shadow: 0 0 0 #006435;
   box-shadow: 0 0 0 #006435;
 }
-<<<<<<< HEAD
 /* line 66, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
 .govuk .button.disabled, .govuk .button[disabled="disabled"], .govuk .button[disabled] {
-=======
-/* line 59, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button.disabled, .button[disabled="disabled"], .button[disabled] {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
   zoom: 1;
   filter: alpha(opacity=50);
   opacity: 0.5;
 }
-<<<<<<< HEAD
 /* line 68, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
 .govuk .button.disabled:hover, .govuk .button[disabled="disabled"]:hover, .govuk .button[disabled]:hover {
   cursor: default;
@@ -731,35 +504,17 @@ textarea {
 }
 /* line 72, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
 .govuk .button.disabled:active, .govuk .button[disabled="disabled"]:active, .govuk .button[disabled]:active {
-=======
-/* line 63, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button.disabled:hover, .button[disabled="disabled"]:hover, .button[disabled]:hover {
-  cursor: default;
-  background-color: #006435;
-}
-/* line 67, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button.disabled:active, .button[disabled="disabled"]:active, .button[disabled]:active {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
   top: 0;
   -webkit-box-shadow: 0 2px 0 #00180c;
   -moz-box-shadow: 0 2px 0 #00180c;
   box-shadow: 0 2px 0 #00180c;
 }
-<<<<<<< HEAD
 /* line 86, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
 .govuk .button:hover, .govuk .button:focus, .govuk .button:visited {
   color: white;
 }
 /* line 100, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
 .govuk .button:before {
-=======
-/* line 79, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button:hover, .button:focus, .button:visited {
-  color: white;
-}
-/* line 95, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button:before {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
   content: "";
   height: 110%;
   width: 100%;
@@ -769,7 +524,6 @@ textarea {
   top: 0;
   left: 0;
 }
-<<<<<<< HEAD
 /* line 110, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
 .govuk .button:active:before {
   top: -10%;
@@ -777,147 +531,36 @@ textarea {
 }
 /* line 123, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
 .govuk .button[rel="external"]:after {
-=======
-/* line 105, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button:active:before {
-  top: -10%;
-  height: 120%;
-}
-/* line 118, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button[rel="external"]:after {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
   display: none;
   content: none;
   margin-left: 0;
   margin-right: 0;
 }
 /* line 7, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
-.govuk .button-secondary {
-  background-color: #dee0e2;
-  position: relative;
-  display: -moz-inline-stack;
-  display: inline-block;
-  padding: 0.35em 0.5em 0.15em 0.5em;
+.govuk .button:focus {
+  outline: 3px solid #ffbf47;
+}
+/* line 11, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link {
+  background: none;
   border: none;
-  -webkit-border-radius: 0.25em;
-  -moz-border-radius: 0.25em;
-  border-radius: 0.25em;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  font-size: 1em;
-  line-height: 1.25;
-  text-decoration: none;
   -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  color: #005ea5;
+  line-height: 1.25;
+  text-decoration: underline;
   cursor: pointer;
-  color: #0b0c0c;
+  margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top;
 }
-<<<<<<< HEAD
-/* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:visited {
-  background-color: #dee0e2;
+/* line 27, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:hover {
+  color: #2e8aca;
 }
-/* line 55, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus {
-  background-color: #d0d3d6;
-}
-/* line 58, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active {
-=======
-/* line 46, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button-secondary:visited {
-  background-color: #dee0e2;
-}
-/* line 49, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button-secondary:hover, .button-secondary:focus {
-  background: #d0d3d6;
-}
-/* line 53, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button-secondary:active {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
-  top: 2px;
-  -webkit-box-shadow: 0 0 0 #dee0e2;
-  -moz-box-shadow: 0 0 0 #dee0e2;
-  box-shadow: 0 0 0 #dee0e2;
-}
-<<<<<<< HEAD
-/* line 66, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled, .govuk .button-secondary[disabled="disabled"], .govuk .button-secondary[disabled] {
-=======
-/* line 59, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button-secondary.disabled, .button-secondary[disabled="disabled"], .button-secondary[disabled] {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
-  zoom: 1;
-  filter: alpha(opacity=50);
-  opacity: 0.5;
-}
-<<<<<<< HEAD
-/* line 68, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:hover, .govuk .button-secondary[disabled="disabled"]:hover, .govuk .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 72, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:active, .govuk .button-secondary[disabled="disabled"]:active, .govuk .button-secondary[disabled]:active {
-=======
-/* line 63, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button-secondary.disabled:hover, .button-secondary[disabled="disabled"]:hover, .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 67, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button-secondary.disabled:active, .button-secondary[disabled="disabled"]:active, .button-secondary[disabled]:active {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
-  top: 0;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-}
-<<<<<<< HEAD
-/* line 93, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus, .govuk .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 100, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:before {
-=======
-/* line 86, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button-secondary:hover, .button-secondary:focus, .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 95, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button-secondary:before {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
-  content: "";
-  height: 110%;
-  width: 100%;
-  display: block;
-  background: transparent;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-<<<<<<< HEAD
-/* line 110, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-}
-/* line 123, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[rel="external"]:after {
-=======
-/* line 105, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-}
-/* line 118, /Users/timpaul/code/gds/design-patterns/../govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.button-secondary[rel="external"]:after {
->>>>>>> 0acdf67bac1284513be4af2f2891882351e3d624
-  display: none;
-  content: none;
-  margin-left: 0;
-  margin-right: 0;
+/* line 30, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:focus {
+  outline: 3px solid #ffbf47;
 }
 /* line 1, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_colours.scss */
 .govuk .text-secondary {
@@ -973,12 +616,16 @@ textarea {
   vertical-align: baseline;
   *vertical-align: middle;
 }
-/* line 16, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
+/* line 15, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
+.govuk legend {
+  padding-left: 0;
+}
+/* line 20, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
 .govuk button,
 .govuk input {
   line-height: normal;
 }
-/* line 34, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
+/* line 38, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
 .govuk input[type="text"],
 .govuk input[type="email"],
 .govuk input[type="date"],
@@ -1001,39 +648,39 @@ textarea {
   -webkit-appearance: none;
   border-radius: 0;
 }
-/* line 46, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
+/* line 50, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
 .govuk textarea {
   overflow: auto;
   vertical-align: top;
   min-height: 190px;
   height: auto;
 }
-/* line 53, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
+/* line 57, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
 .govuk .form-group {
   margin-bottom: 15px;
 }
 @media (min-width: 641px) {
-  /* line 53, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
+  /* line 57, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
   .govuk .form-group {
     margin-bottom: 30px;
   }
 }
-/* line 60, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
+/* line 64, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
 .govuk .form-group label {
   display: block;
   margin-bottom: 5px;
 }
-/* line 65, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
+/* line 69, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
 .govuk .form-control {
   width: 96%;
 }
 @media (min-width: 641px) {
-  /* line 65, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
+  /* line 69, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
   .govuk .form-control {
     width: 350px;
   }
 }
-/* line 72, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
+/* line 76, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
 .govuk .hint {
   display: block;
   color: #6f777b;
@@ -1045,7 +692,7 @@ textarea {
   margin-top: 8px;
 }
 @media (max-width: 640px) {
-  /* line 72, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
+  /* line 76, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_forms.scss */
   .govuk .hint {
     font-size: 14px;
     line-height: 1.14286;

--- a/assets/stylesheets/example-grids/example-grids-ie6.css
+++ b/assets/stylesheets/example-grids/example-grids-ie6.css
@@ -501,18 +501,21 @@ Example usage:
 .govuk .button-link {
   background: none;
   border: none;
-  line-height: 1.25;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
   color: #005ea5;
+  line-height: 1.25;
   text-decoration: underline;
   cursor: pointer;
+  margin: 0 15px 15px 0;
   padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
-/* line 25, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+/* line 27, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
 .govuk .button-link:hover {
   color: #2e8aca;
 }
-/* line 28, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+/* line 30, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
 .govuk .button-link:focus {
   outline: 3px solid #ffbf47;
 }

--- a/assets/stylesheets/example-grids/example-grids-ie6.css
+++ b/assets/stylesheets/example-grids/example-grids-ie6.css
@@ -419,6 +419,7 @@ Example usage:
   cursor: pointer;
   color: white;
   margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
 /* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
@@ -493,100 +494,30 @@ Example usage:
   filter: none;
 }
 /* line 7, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
-.govuk .button-secondary {
-  background-color: #dee0e2;
-  position: relative;
-  display: -moz-inline-stack;
-  display: inline-block;
-  zoom: 1;
-  display: inline;
-  padding: 0.35em 0.5em 0.15em 0.5em;
+.govuk .button:focus {
+  outline: 3px solid #ffbf47;
+}
+/* line 11, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link {
+  background: none;
   border: none;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-  border-radius: 0;
-  -webkit-appearance: none;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-  font-size: 1em;
-  line-height: 1.25;
-  text-decoration: none;
   -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  color: #005ea5;
+  line-height: 1.25;
+  text-decoration: underline;
   cursor: pointer;
-  color: #0b0c0c;
+  margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top;
 }
-/* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:visited {
-  background-color: #dee0e2;
+/* line 27, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:hover {
+  color: #2e8aca;
 }
-/* line 55, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus {
-  background-color: #d0d3d6;
-}
-/* line 58, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active {
-  top: 2px;
-  -webkit-box-shadow: 0 0 0 #dee0e2;
-  -moz-box-shadow: 0 0 0 #dee0e2;
-  box-shadow: 0 0 0 #dee0e2;
-}
-/* line 66, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled, .govuk .button-secondary[disabled="disabled"], .govuk .button-secondary[disabled] {
-  zoom: 1;
-  filter: alpha(opacity=50);
-  opacity: 0.5;
-}
-/* line 68, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:hover, .govuk .button-secondary[disabled="disabled"]:hover, .govuk .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 72, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:active, .govuk .button-secondary[disabled="disabled"]:active, .govuk .button-secondary[disabled]:active {
-  top: 0;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-}
-/* line 93, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus, .govuk .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 100, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:before {
-  content: "";
-  height: 110%;
-  width: 100%;
-  display: block;
-  background: transparent;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-/* line 110, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-  top: auto;
-  height: 100%;
-}
-/* line 123, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[rel="external"]:after {
-  display: none;
-  content: none;
-  margin-left: 0;
-  margin-right: 0;
-}
-/* line 134, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type="submit"], .govuk .button-secondary[type="reset"], .govuk .button-secondary[type="button"] {
-  filter: chroma(color=black);
-}
-/* line 138, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type=submit].button {
-  filter: none;
+/* line 30, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:focus {
+  outline: 3px solid #ffbf47;
 }
 /* line 1, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_colours.scss */
 .govuk .text-secondary {

--- a/assets/stylesheets/example-grids/example-grids-ie6.css
+++ b/assets/stylesheets/example-grids/example-grids-ie6.css
@@ -419,6 +419,7 @@ Example usage:
   cursor: pointer;
   color: white;
   margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
 /* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
@@ -493,100 +494,27 @@ Example usage:
   filter: none;
 }
 /* line 7, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
-.govuk .button-secondary {
-  background-color: #dee0e2;
-  position: relative;
-  display: -moz-inline-stack;
-  display: inline-block;
-  zoom: 1;
-  display: inline;
-  padding: 0.35em 0.5em 0.15em 0.5em;
+.govuk .button:focus {
+  outline: 3px solid #ffbf47;
+}
+/* line 11, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link {
+  background: none;
   border: none;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-  border-radius: 0;
-  -webkit-appearance: none;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-  font-size: 1em;
   line-height: 1.25;
-  text-decoration: none;
-  -webkit-font-smoothing: antialiased;
+  color: #005ea5;
+  text-decoration: underline;
   cursor: pointer;
-  color: #0b0c0c;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top;
 }
-/* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:visited {
-  background-color: #dee0e2;
+/* line 25, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:hover {
+  color: #2e8aca;
 }
-/* line 55, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus {
-  background-color: #d0d3d6;
-}
-/* line 58, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active {
-  top: 2px;
-  -webkit-box-shadow: 0 0 0 #dee0e2;
-  -moz-box-shadow: 0 0 0 #dee0e2;
-  box-shadow: 0 0 0 #dee0e2;
-}
-/* line 66, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled, .govuk .button-secondary[disabled="disabled"], .govuk .button-secondary[disabled] {
-  zoom: 1;
-  filter: alpha(opacity=50);
-  opacity: 0.5;
-}
-/* line 68, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:hover, .govuk .button-secondary[disabled="disabled"]:hover, .govuk .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 72, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:active, .govuk .button-secondary[disabled="disabled"]:active, .govuk .button-secondary[disabled]:active {
-  top: 0;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-}
-/* line 93, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus, .govuk .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 100, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:before {
-  content: "";
-  height: 110%;
-  width: 100%;
-  display: block;
-  background: transparent;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-/* line 110, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-  top: auto;
-  height: 100%;
-}
-/* line 123, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[rel="external"]:after {
-  display: none;
-  content: none;
-  margin-left: 0;
-  margin-right: 0;
-}
-/* line 134, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type="submit"], .govuk .button-secondary[type="reset"], .govuk .button-secondary[type="button"] {
-  filter: chroma(color=black);
-}
-/* line 138, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type=submit].button {
-  filter: none;
+/* line 28, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:focus {
+  outline: 3px solid #ffbf47;
 }
 /* line 1, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_colours.scss */
 .govuk .text-secondary {

--- a/assets/stylesheets/example-grids/example-grids-ie7.css
+++ b/assets/stylesheets/example-grids/example-grids-ie7.css
@@ -436,6 +436,7 @@ Example usage:
   cursor: pointer;
   color: white;
   margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
 /* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
@@ -508,98 +509,27 @@ Example usage:
   filter: none;
 }
 /* line 7, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
-.govuk .button-secondary {
-  background-color: #dee0e2;
-  position: relative;
-  display: -moz-inline-stack;
-  display: inline-block;
-  zoom: 1;
-  display: inline;
-  padding: 0.35em 0.5em 0.15em 0.5em;
+.govuk .button:focus {
+  outline: 3px solid #ffbf47;
+}
+/* line 11, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link {
+  background: none;
   border: none;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-  border-radius: 0;
-  -webkit-appearance: none;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-  font-size: 1em;
   line-height: 1.25;
-  text-decoration: none;
-  -webkit-font-smoothing: antialiased;
+  color: #005ea5;
+  text-decoration: underline;
   cursor: pointer;
-  color: #0b0c0c;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top;
 }
-/* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:visited {
-  background-color: #dee0e2;
+/* line 25, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:hover {
+  color: #2e8aca;
 }
-/* line 55, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus {
-  background-color: #d0d3d6;
-}
-/* line 58, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active {
-  top: 2px;
-  -webkit-box-shadow: 0 0 0 #dee0e2;
-  -moz-box-shadow: 0 0 0 #dee0e2;
-  box-shadow: 0 0 0 #dee0e2;
-}
-/* line 66, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled, .govuk .button-secondary[disabled="disabled"], .govuk .button-secondary[disabled] {
-  zoom: 1;
-  filter: alpha(opacity=50);
-  opacity: 0.5;
-}
-/* line 68, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:hover, .govuk .button-secondary[disabled="disabled"]:hover, .govuk .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 72, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:active, .govuk .button-secondary[disabled="disabled"]:active, .govuk .button-secondary[disabled]:active {
-  top: 0;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-}
-/* line 93, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus, .govuk .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 100, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:before {
-  content: "";
-  height: 110%;
-  width: 100%;
-  display: block;
-  background: transparent;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-/* line 110, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-}
-/* line 123, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[rel="external"]:after {
-  display: none;
-  content: none;
-  margin-left: 0;
-  margin-right: 0;
-}
-/* line 134, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type="submit"], .govuk .button-secondary[type="reset"], .govuk .button-secondary[type="button"] {
-  filter: chroma(color=black);
-}
-/* line 138, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type=submit].button {
-  filter: none;
+/* line 28, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:focus {
+  outline: 3px solid #ffbf47;
 }
 /* line 1, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_colours.scss */
 .govuk .text-secondary {

--- a/assets/stylesheets/example-grids/example-grids-ie7.css
+++ b/assets/stylesheets/example-grids/example-grids-ie7.css
@@ -436,6 +436,7 @@ Example usage:
   cursor: pointer;
   color: white;
   margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
 /* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
@@ -508,98 +509,30 @@ Example usage:
   filter: none;
 }
 /* line 7, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
-.govuk .button-secondary {
-  background-color: #dee0e2;
-  position: relative;
-  display: -moz-inline-stack;
-  display: inline-block;
-  zoom: 1;
-  display: inline;
-  padding: 0.35em 0.5em 0.15em 0.5em;
+.govuk .button:focus {
+  outline: 3px solid #ffbf47;
+}
+/* line 11, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link {
+  background: none;
   border: none;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-  border-radius: 0;
-  -webkit-appearance: none;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-  font-size: 1em;
-  line-height: 1.25;
-  text-decoration: none;
   -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  color: #005ea5;
+  line-height: 1.25;
+  text-decoration: underline;
   cursor: pointer;
-  color: #0b0c0c;
+  margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top;
 }
-/* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:visited {
-  background-color: #dee0e2;
+/* line 27, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:hover {
+  color: #2e8aca;
 }
-/* line 55, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus {
-  background-color: #d0d3d6;
-}
-/* line 58, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active {
-  top: 2px;
-  -webkit-box-shadow: 0 0 0 #dee0e2;
-  -moz-box-shadow: 0 0 0 #dee0e2;
-  box-shadow: 0 0 0 #dee0e2;
-}
-/* line 66, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled, .govuk .button-secondary[disabled="disabled"], .govuk .button-secondary[disabled] {
-  zoom: 1;
-  filter: alpha(opacity=50);
-  opacity: 0.5;
-}
-/* line 68, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:hover, .govuk .button-secondary[disabled="disabled"]:hover, .govuk .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 72, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:active, .govuk .button-secondary[disabled="disabled"]:active, .govuk .button-secondary[disabled]:active {
-  top: 0;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-}
-/* line 93, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus, .govuk .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 100, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:before {
-  content: "";
-  height: 110%;
-  width: 100%;
-  display: block;
-  background: transparent;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-/* line 110, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-}
-/* line 123, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[rel="external"]:after {
-  display: none;
-  content: none;
-  margin-left: 0;
-  margin-right: 0;
-}
-/* line 134, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type="submit"], .govuk .button-secondary[type="reset"], .govuk .button-secondary[type="button"] {
-  filter: chroma(color=black);
-}
-/* line 138, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type=submit].button {
-  filter: none;
+/* line 30, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:focus {
+  outline: 3px solid #ffbf47;
 }
 /* line 1, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_colours.scss */
 .govuk .text-secondary {

--- a/assets/stylesheets/example-grids/example-grids-ie7.css
+++ b/assets/stylesheets/example-grids/example-grids-ie7.css
@@ -516,18 +516,21 @@ Example usage:
 .govuk .button-link {
   background: none;
   border: none;
-  line-height: 1.25;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
   color: #005ea5;
+  line-height: 1.25;
   text-decoration: underline;
   cursor: pointer;
+  margin: 0 15px 15px 0;
   padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
-/* line 25, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+/* line 27, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
 .govuk .button-link:hover {
   color: #2e8aca;
 }
-/* line 28, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+/* line 30, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
 .govuk .button-link:focus {
   outline: 3px solid #ffbf47;
 }

--- a/assets/stylesheets/example-grids/example-grids-ie8.css
+++ b/assets/stylesheets/example-grids/example-grids-ie8.css
@@ -422,6 +422,7 @@ Example usage:
   cursor: pointer;
   color: white;
   margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
 /* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
@@ -494,96 +495,27 @@ Example usage:
   filter: none;
 }
 /* line 7, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
-.govuk .button-secondary {
-  background-color: #dee0e2;
-  position: relative;
-  display: -moz-inline-stack;
-  display: inline-block;
-  padding: 0.35em 0.5em 0.15em 0.5em;
+.govuk .button:focus {
+  outline: 3px solid #ffbf47;
+}
+/* line 11, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link {
+  background: none;
   border: none;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-  border-radius: 0;
-  -webkit-appearance: none;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-  font-size: 1em;
   line-height: 1.25;
-  text-decoration: none;
-  -webkit-font-smoothing: antialiased;
+  color: #005ea5;
+  text-decoration: underline;
   cursor: pointer;
-  color: #0b0c0c;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top;
 }
-/* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:visited {
-  background-color: #dee0e2;
+/* line 25, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:hover {
+  color: #2e8aca;
 }
-/* line 55, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus {
-  background-color: #d0d3d6;
-}
-/* line 58, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active {
-  top: 2px;
-  -webkit-box-shadow: 0 0 0 #dee0e2;
-  -moz-box-shadow: 0 0 0 #dee0e2;
-  box-shadow: 0 0 0 #dee0e2;
-}
-/* line 66, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled, .govuk .button-secondary[disabled="disabled"], .govuk .button-secondary[disabled] {
-  zoom: 1;
-  filter: alpha(opacity=50);
-  opacity: 0.5;
-}
-/* line 68, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:hover, .govuk .button-secondary[disabled="disabled"]:hover, .govuk .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 72, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:active, .govuk .button-secondary[disabled="disabled"]:active, .govuk .button-secondary[disabled]:active {
-  top: 0;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-}
-/* line 93, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus, .govuk .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 100, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:before {
-  content: "";
-  height: 110%;
-  width: 100%;
-  display: block;
-  background: transparent;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-/* line 110, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-}
-/* line 123, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[rel="external"]:after {
-  display: none;
-  content: none;
-  margin-left: 0;
-  margin-right: 0;
-}
-/* line 134, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type="submit"], .govuk .button-secondary[type="reset"], .govuk .button-secondary[type="button"] {
-  filter: chroma(color=black);
-}
-/* line 138, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type=submit].button {
-  filter: none;
+/* line 28, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:focus {
+  outline: 3px solid #ffbf47;
 }
 /* line 1, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_colours.scss */
 .govuk .text-secondary {

--- a/assets/stylesheets/example-grids/example-grids-ie8.css
+++ b/assets/stylesheets/example-grids/example-grids-ie8.css
@@ -502,18 +502,21 @@ Example usage:
 .govuk .button-link {
   background: none;
   border: none;
-  line-height: 1.25;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
   color: #005ea5;
+  line-height: 1.25;
   text-decoration: underline;
   cursor: pointer;
+  margin: 0 15px 15px 0;
   padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
-/* line 25, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+/* line 27, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
 .govuk .button-link:hover {
   color: #2e8aca;
 }
-/* line 28, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+/* line 30, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
 .govuk .button-link:focus {
   outline: 3px solid #ffbf47;
 }

--- a/assets/stylesheets/example-grids/example-grids-ie8.css
+++ b/assets/stylesheets/example-grids/example-grids-ie8.css
@@ -422,6 +422,7 @@ Example usage:
   cursor: pointer;
   color: white;
   margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
 /* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
@@ -494,96 +495,30 @@ Example usage:
   filter: none;
 }
 /* line 7, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
-.govuk .button-secondary {
-  background-color: #dee0e2;
-  position: relative;
-  display: -moz-inline-stack;
-  display: inline-block;
-  padding: 0.35em 0.5em 0.15em 0.5em;
+.govuk .button:focus {
+  outline: 3px solid #ffbf47;
+}
+/* line 11, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link {
+  background: none;
   border: none;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-  border-radius: 0;
-  -webkit-appearance: none;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-  font-size: 1em;
-  line-height: 1.25;
-  text-decoration: none;
   -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  color: #005ea5;
+  line-height: 1.25;
+  text-decoration: underline;
   cursor: pointer;
-  color: #0b0c0c;
+  margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top;
 }
-/* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:visited {
-  background-color: #dee0e2;
+/* line 27, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:hover {
+  color: #2e8aca;
 }
-/* line 55, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus {
-  background-color: #d0d3d6;
-}
-/* line 58, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active {
-  top: 2px;
-  -webkit-box-shadow: 0 0 0 #dee0e2;
-  -moz-box-shadow: 0 0 0 #dee0e2;
-  box-shadow: 0 0 0 #dee0e2;
-}
-/* line 66, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled, .govuk .button-secondary[disabled="disabled"], .govuk .button-secondary[disabled] {
-  zoom: 1;
-  filter: alpha(opacity=50);
-  opacity: 0.5;
-}
-/* line 68, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:hover, .govuk .button-secondary[disabled="disabled"]:hover, .govuk .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 72, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:active, .govuk .button-secondary[disabled="disabled"]:active, .govuk .button-secondary[disabled]:active {
-  top: 0;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-}
-/* line 93, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus, .govuk .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 100, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:before {
-  content: "";
-  height: 110%;
-  width: 100%;
-  display: block;
-  background: transparent;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-/* line 110, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-}
-/* line 123, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[rel="external"]:after {
-  display: none;
-  content: none;
-  margin-left: 0;
-  margin-right: 0;
-}
-/* line 134, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type="submit"], .govuk .button-secondary[type="reset"], .govuk .button-secondary[type="button"] {
-  filter: chroma(color=black);
-}
-/* line 138, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type=submit].button {
-  filter: none;
+/* line 30, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:focus {
+  outline: 3px solid #ffbf47;
 }
 /* line 1, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_colours.scss */
 .govuk .text-secondary {

--- a/assets/stylesheets/example-grids/example-grids.css
+++ b/assets/stylesheets/example-grids/example-grids.css
@@ -544,18 +544,21 @@ Example usage:
 .govuk .button-link {
   background: none;
   border: none;
-  line-height: 1.25;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
   color: #005ea5;
+  line-height: 1.25;
   text-decoration: underline;
   cursor: pointer;
+  margin: 0 15px 15px 0;
   padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
-/* line 25, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+/* line 27, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
 .govuk .button-link:hover {
   color: #2e8aca;
 }
-/* line 28, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+/* line 30, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
 .govuk .button-link:focus {
   outline: 3px solid #ffbf47;
 }

--- a/assets/stylesheets/example-grids/example-grids.css
+++ b/assets/stylesheets/example-grids/example-grids.css
@@ -473,6 +473,7 @@ Example usage:
   cursor: pointer;
   color: white;
   margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
 /* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
@@ -536,86 +537,27 @@ Example usage:
   margin-right: 0;
 }
 /* line 7, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
-.govuk .button-secondary {
-  background-color: #dee0e2;
-  position: relative;
-  display: -moz-inline-stack;
-  display: inline-block;
-  padding: 0.35em 0.5em 0.15em 0.5em;
+.govuk .button:focus {
+  outline: 3px solid #ffbf47;
+}
+/* line 11, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link {
+  background: none;
   border: none;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-  border-radius: 0;
-  -webkit-appearance: none;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  font-size: 1em;
   line-height: 1.25;
-  text-decoration: none;
-  -webkit-font-smoothing: antialiased;
+  color: #005ea5;
+  text-decoration: underline;
   cursor: pointer;
-  color: #0b0c0c;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top;
 }
-/* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:visited {
-  background-color: #dee0e2;
+/* line 25, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:hover {
+  color: #2e8aca;
 }
-/* line 55, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus {
-  background-color: #d0d3d6;
-}
-/* line 58, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active {
-  top: 2px;
-  -webkit-box-shadow: 0 0 0 #dee0e2;
-  -moz-box-shadow: 0 0 0 #dee0e2;
-  box-shadow: 0 0 0 #dee0e2;
-}
-/* line 66, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled, .govuk .button-secondary[disabled="disabled"], .govuk .button-secondary[disabled] {
-  zoom: 1;
-  filter: alpha(opacity=50);
-  opacity: 0.5;
-}
-/* line 68, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:hover, .govuk .button-secondary[disabled="disabled"]:hover, .govuk .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 72, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:active, .govuk .button-secondary[disabled="disabled"]:active, .govuk .button-secondary[disabled]:active {
-  top: 0;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-}
-/* line 93, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus, .govuk .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 100, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:before {
-  content: "";
-  height: 110%;
-  width: 100%;
-  display: block;
-  background: transparent;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-/* line 110, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-}
-/* line 123, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[rel="external"]:after {
-  display: none;
-  content: none;
-  margin-left: 0;
-  margin-right: 0;
+/* line 28, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:focus {
+  outline: 3px solid #ffbf47;
 }
 /* line 1, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_colours.scss */
 .govuk .text-secondary {

--- a/assets/stylesheets/example-grids/example-grids.css
+++ b/assets/stylesheets/example-grids/example-grids.css
@@ -473,6 +473,7 @@ Example usage:
   cursor: pointer;
   color: white;
   margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
 /* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
@@ -536,86 +537,30 @@ Example usage:
   margin-right: 0;
 }
 /* line 7, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
-.govuk .button-secondary {
-  background-color: #dee0e2;
-  position: relative;
-  display: -moz-inline-stack;
-  display: inline-block;
-  padding: 0.35em 0.5em 0.15em 0.5em;
+.govuk .button:focus {
+  outline: 3px solid #ffbf47;
+}
+/* line 11, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link {
+  background: none;
   border: none;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-  border-radius: 0;
-  -webkit-appearance: none;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  font-size: 1em;
-  line-height: 1.25;
-  text-decoration: none;
   -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  color: #005ea5;
+  line-height: 1.25;
+  text-decoration: underline;
   cursor: pointer;
-  color: #0b0c0c;
+  margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top;
 }
-/* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:visited {
-  background-color: #dee0e2;
+/* line 27, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:hover {
+  color: #2e8aca;
 }
-/* line 55, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus {
-  background-color: #d0d3d6;
-}
-/* line 58, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active {
-  top: 2px;
-  -webkit-box-shadow: 0 0 0 #dee0e2;
-  -moz-box-shadow: 0 0 0 #dee0e2;
-  box-shadow: 0 0 0 #dee0e2;
-}
-/* line 66, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled, .govuk .button-secondary[disabled="disabled"], .govuk .button-secondary[disabled] {
-  zoom: 1;
-  filter: alpha(opacity=50);
-  opacity: 0.5;
-}
-/* line 68, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:hover, .govuk .button-secondary[disabled="disabled"]:hover, .govuk .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 72, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:active, .govuk .button-secondary[disabled="disabled"]:active, .govuk .button-secondary[disabled]:active {
-  top: 0;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-}
-/* line 93, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus, .govuk .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 100, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:before {
-  content: "";
-  height: 110%;
-  width: 100%;
-  display: block;
-  background: transparent;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-/* line 110, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-}
-/* line 123, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[rel="external"]:after {
-  display: none;
-  content: none;
-  margin-left: 0;
-  margin-right: 0;
+/* line 30, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:focus {
+  outline: 3px solid #ffbf47;
 }
 /* line 1, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_colours.scss */
 .govuk .text-secondary {

--- a/assets/stylesheets/example-typography/example-typography-ie6.css
+++ b/assets/stylesheets/example-typography/example-typography-ie6.css
@@ -501,18 +501,21 @@ Example usage:
 .govuk .button-link {
   background: none;
   border: none;
-  line-height: 1.25;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
   color: #005ea5;
+  line-height: 1.25;
   text-decoration: underline;
   cursor: pointer;
+  margin: 0 15px 15px 0;
   padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
-/* line 25, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+/* line 27, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
 .govuk .button-link:hover {
   color: #2e8aca;
 }
-/* line 28, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+/* line 30, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
 .govuk .button-link:focus {
   outline: 3px solid #ffbf47;
 }

--- a/assets/stylesheets/example-typography/example-typography-ie6.css
+++ b/assets/stylesheets/example-typography/example-typography-ie6.css
@@ -419,6 +419,7 @@ Example usage:
   cursor: pointer;
   color: white;
   margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
 /* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
@@ -493,100 +494,30 @@ Example usage:
   filter: none;
 }
 /* line 7, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
-.govuk .button-secondary {
-  background-color: #dee0e2;
-  position: relative;
-  display: -moz-inline-stack;
-  display: inline-block;
-  zoom: 1;
-  display: inline;
-  padding: 0.35em 0.5em 0.15em 0.5em;
+.govuk .button:focus {
+  outline: 3px solid #ffbf47;
+}
+/* line 11, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link {
+  background: none;
   border: none;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-  border-radius: 0;
-  -webkit-appearance: none;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-  font-size: 1em;
-  line-height: 1.25;
-  text-decoration: none;
   -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  color: #005ea5;
+  line-height: 1.25;
+  text-decoration: underline;
   cursor: pointer;
-  color: #0b0c0c;
+  margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top;
 }
-/* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:visited {
-  background-color: #dee0e2;
+/* line 27, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:hover {
+  color: #2e8aca;
 }
-/* line 55, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus {
-  background-color: #d0d3d6;
-}
-/* line 58, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active {
-  top: 2px;
-  -webkit-box-shadow: 0 0 0 #dee0e2;
-  -moz-box-shadow: 0 0 0 #dee0e2;
-  box-shadow: 0 0 0 #dee0e2;
-}
-/* line 66, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled, .govuk .button-secondary[disabled="disabled"], .govuk .button-secondary[disabled] {
-  zoom: 1;
-  filter: alpha(opacity=50);
-  opacity: 0.5;
-}
-/* line 68, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:hover, .govuk .button-secondary[disabled="disabled"]:hover, .govuk .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 72, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:active, .govuk .button-secondary[disabled="disabled"]:active, .govuk .button-secondary[disabled]:active {
-  top: 0;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-}
-/* line 93, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus, .govuk .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 100, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:before {
-  content: "";
-  height: 110%;
-  width: 100%;
-  display: block;
-  background: transparent;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-/* line 110, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-  top: auto;
-  height: 100%;
-}
-/* line 123, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[rel="external"]:after {
-  display: none;
-  content: none;
-  margin-left: 0;
-  margin-right: 0;
-}
-/* line 134, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type="submit"], .govuk .button-secondary[type="reset"], .govuk .button-secondary[type="button"] {
-  filter: chroma(color=black);
-}
-/* line 138, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type=submit].button {
-  filter: none;
+/* line 30, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:focus {
+  outline: 3px solid #ffbf47;
 }
 /* line 1, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_colours.scss */
 .govuk .text-secondary {

--- a/assets/stylesheets/example-typography/example-typography-ie6.css
+++ b/assets/stylesheets/example-typography/example-typography-ie6.css
@@ -419,6 +419,7 @@ Example usage:
   cursor: pointer;
   color: white;
   margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
 /* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
@@ -493,100 +494,27 @@ Example usage:
   filter: none;
 }
 /* line 7, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
-.govuk .button-secondary {
-  background-color: #dee0e2;
-  position: relative;
-  display: -moz-inline-stack;
-  display: inline-block;
-  zoom: 1;
-  display: inline;
-  padding: 0.35em 0.5em 0.15em 0.5em;
+.govuk .button:focus {
+  outline: 3px solid #ffbf47;
+}
+/* line 11, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link {
+  background: none;
   border: none;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-  border-radius: 0;
-  -webkit-appearance: none;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-  font-size: 1em;
   line-height: 1.25;
-  text-decoration: none;
-  -webkit-font-smoothing: antialiased;
+  color: #005ea5;
+  text-decoration: underline;
   cursor: pointer;
-  color: #0b0c0c;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top;
 }
-/* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:visited {
-  background-color: #dee0e2;
+/* line 25, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:hover {
+  color: #2e8aca;
 }
-/* line 55, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus {
-  background-color: #d0d3d6;
-}
-/* line 58, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active {
-  top: 2px;
-  -webkit-box-shadow: 0 0 0 #dee0e2;
-  -moz-box-shadow: 0 0 0 #dee0e2;
-  box-shadow: 0 0 0 #dee0e2;
-}
-/* line 66, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled, .govuk .button-secondary[disabled="disabled"], .govuk .button-secondary[disabled] {
-  zoom: 1;
-  filter: alpha(opacity=50);
-  opacity: 0.5;
-}
-/* line 68, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:hover, .govuk .button-secondary[disabled="disabled"]:hover, .govuk .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 72, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:active, .govuk .button-secondary[disabled="disabled"]:active, .govuk .button-secondary[disabled]:active {
-  top: 0;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-}
-/* line 93, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus, .govuk .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 100, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:before {
-  content: "";
-  height: 110%;
-  width: 100%;
-  display: block;
-  background: transparent;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-/* line 110, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-  top: auto;
-  height: 100%;
-}
-/* line 123, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[rel="external"]:after {
-  display: none;
-  content: none;
-  margin-left: 0;
-  margin-right: 0;
-}
-/* line 134, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type="submit"], .govuk .button-secondary[type="reset"], .govuk .button-secondary[type="button"] {
-  filter: chroma(color=black);
-}
-/* line 138, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type=submit].button {
-  filter: none;
+/* line 28, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:focus {
+  outline: 3px solid #ffbf47;
 }
 /* line 1, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_colours.scss */
 .govuk .text-secondary {

--- a/assets/stylesheets/example-typography/example-typography-ie7.css
+++ b/assets/stylesheets/example-typography/example-typography-ie7.css
@@ -436,6 +436,7 @@ Example usage:
   cursor: pointer;
   color: white;
   margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
 /* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
@@ -508,98 +509,27 @@ Example usage:
   filter: none;
 }
 /* line 7, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
-.govuk .button-secondary {
-  background-color: #dee0e2;
-  position: relative;
-  display: -moz-inline-stack;
-  display: inline-block;
-  zoom: 1;
-  display: inline;
-  padding: 0.35em 0.5em 0.15em 0.5em;
+.govuk .button:focus {
+  outline: 3px solid #ffbf47;
+}
+/* line 11, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link {
+  background: none;
   border: none;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-  border-radius: 0;
-  -webkit-appearance: none;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-  font-size: 1em;
   line-height: 1.25;
-  text-decoration: none;
-  -webkit-font-smoothing: antialiased;
+  color: #005ea5;
+  text-decoration: underline;
   cursor: pointer;
-  color: #0b0c0c;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top;
 }
-/* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:visited {
-  background-color: #dee0e2;
+/* line 25, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:hover {
+  color: #2e8aca;
 }
-/* line 55, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus {
-  background-color: #d0d3d6;
-}
-/* line 58, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active {
-  top: 2px;
-  -webkit-box-shadow: 0 0 0 #dee0e2;
-  -moz-box-shadow: 0 0 0 #dee0e2;
-  box-shadow: 0 0 0 #dee0e2;
-}
-/* line 66, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled, .govuk .button-secondary[disabled="disabled"], .govuk .button-secondary[disabled] {
-  zoom: 1;
-  filter: alpha(opacity=50);
-  opacity: 0.5;
-}
-/* line 68, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:hover, .govuk .button-secondary[disabled="disabled"]:hover, .govuk .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 72, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:active, .govuk .button-secondary[disabled="disabled"]:active, .govuk .button-secondary[disabled]:active {
-  top: 0;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-}
-/* line 93, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus, .govuk .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 100, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:before {
-  content: "";
-  height: 110%;
-  width: 100%;
-  display: block;
-  background: transparent;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-/* line 110, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-}
-/* line 123, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[rel="external"]:after {
-  display: none;
-  content: none;
-  margin-left: 0;
-  margin-right: 0;
-}
-/* line 134, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type="submit"], .govuk .button-secondary[type="reset"], .govuk .button-secondary[type="button"] {
-  filter: chroma(color=black);
-}
-/* line 138, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type=submit].button {
-  filter: none;
+/* line 28, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:focus {
+  outline: 3px solid #ffbf47;
 }
 /* line 1, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_colours.scss */
 .govuk .text-secondary {

--- a/assets/stylesheets/example-typography/example-typography-ie7.css
+++ b/assets/stylesheets/example-typography/example-typography-ie7.css
@@ -436,6 +436,7 @@ Example usage:
   cursor: pointer;
   color: white;
   margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
 /* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
@@ -508,98 +509,30 @@ Example usage:
   filter: none;
 }
 /* line 7, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
-.govuk .button-secondary {
-  background-color: #dee0e2;
-  position: relative;
-  display: -moz-inline-stack;
-  display: inline-block;
-  zoom: 1;
-  display: inline;
-  padding: 0.35em 0.5em 0.15em 0.5em;
+.govuk .button:focus {
+  outline: 3px solid #ffbf47;
+}
+/* line 11, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link {
+  background: none;
   border: none;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-  border-radius: 0;
-  -webkit-appearance: none;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-  font-size: 1em;
-  line-height: 1.25;
-  text-decoration: none;
   -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  color: #005ea5;
+  line-height: 1.25;
+  text-decoration: underline;
   cursor: pointer;
-  color: #0b0c0c;
+  margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top;
 }
-/* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:visited {
-  background-color: #dee0e2;
+/* line 27, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:hover {
+  color: #2e8aca;
 }
-/* line 55, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus {
-  background-color: #d0d3d6;
-}
-/* line 58, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active {
-  top: 2px;
-  -webkit-box-shadow: 0 0 0 #dee0e2;
-  -moz-box-shadow: 0 0 0 #dee0e2;
-  box-shadow: 0 0 0 #dee0e2;
-}
-/* line 66, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled, .govuk .button-secondary[disabled="disabled"], .govuk .button-secondary[disabled] {
-  zoom: 1;
-  filter: alpha(opacity=50);
-  opacity: 0.5;
-}
-/* line 68, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:hover, .govuk .button-secondary[disabled="disabled"]:hover, .govuk .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 72, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:active, .govuk .button-secondary[disabled="disabled"]:active, .govuk .button-secondary[disabled]:active {
-  top: 0;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-}
-/* line 93, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus, .govuk .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 100, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:before {
-  content: "";
-  height: 110%;
-  width: 100%;
-  display: block;
-  background: transparent;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-/* line 110, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-}
-/* line 123, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[rel="external"]:after {
-  display: none;
-  content: none;
-  margin-left: 0;
-  margin-right: 0;
-}
-/* line 134, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type="submit"], .govuk .button-secondary[type="reset"], .govuk .button-secondary[type="button"] {
-  filter: chroma(color=black);
-}
-/* line 138, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type=submit].button {
-  filter: none;
+/* line 30, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:focus {
+  outline: 3px solid #ffbf47;
 }
 /* line 1, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_colours.scss */
 .govuk .text-secondary {

--- a/assets/stylesheets/example-typography/example-typography-ie7.css
+++ b/assets/stylesheets/example-typography/example-typography-ie7.css
@@ -516,18 +516,21 @@ Example usage:
 .govuk .button-link {
   background: none;
   border: none;
-  line-height: 1.25;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
   color: #005ea5;
+  line-height: 1.25;
   text-decoration: underline;
   cursor: pointer;
+  margin: 0 15px 15px 0;
   padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
-/* line 25, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+/* line 27, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
 .govuk .button-link:hover {
   color: #2e8aca;
 }
-/* line 28, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+/* line 30, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
 .govuk .button-link:focus {
   outline: 3px solid #ffbf47;
 }

--- a/assets/stylesheets/example-typography/example-typography-ie8.css
+++ b/assets/stylesheets/example-typography/example-typography-ie8.css
@@ -422,6 +422,7 @@ Example usage:
   cursor: pointer;
   color: white;
   margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
 /* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
@@ -494,96 +495,27 @@ Example usage:
   filter: none;
 }
 /* line 7, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
-.govuk .button-secondary {
-  background-color: #dee0e2;
-  position: relative;
-  display: -moz-inline-stack;
-  display: inline-block;
-  padding: 0.35em 0.5em 0.15em 0.5em;
+.govuk .button:focus {
+  outline: 3px solid #ffbf47;
+}
+/* line 11, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link {
+  background: none;
   border: none;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-  border-radius: 0;
-  -webkit-appearance: none;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-  font-size: 1em;
   line-height: 1.25;
-  text-decoration: none;
-  -webkit-font-smoothing: antialiased;
+  color: #005ea5;
+  text-decoration: underline;
   cursor: pointer;
-  color: #0b0c0c;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top;
 }
-/* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:visited {
-  background-color: #dee0e2;
+/* line 25, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:hover {
+  color: #2e8aca;
 }
-/* line 55, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus {
-  background-color: #d0d3d6;
-}
-/* line 58, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active {
-  top: 2px;
-  -webkit-box-shadow: 0 0 0 #dee0e2;
-  -moz-box-shadow: 0 0 0 #dee0e2;
-  box-shadow: 0 0 0 #dee0e2;
-}
-/* line 66, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled, .govuk .button-secondary[disabled="disabled"], .govuk .button-secondary[disabled] {
-  zoom: 1;
-  filter: alpha(opacity=50);
-  opacity: 0.5;
-}
-/* line 68, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:hover, .govuk .button-secondary[disabled="disabled"]:hover, .govuk .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 72, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:active, .govuk .button-secondary[disabled="disabled"]:active, .govuk .button-secondary[disabled]:active {
-  top: 0;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-}
-/* line 93, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus, .govuk .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 100, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:before {
-  content: "";
-  height: 110%;
-  width: 100%;
-  display: block;
-  background: transparent;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-/* line 110, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-}
-/* line 123, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[rel="external"]:after {
-  display: none;
-  content: none;
-  margin-left: 0;
-  margin-right: 0;
-}
-/* line 134, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type="submit"], .govuk .button-secondary[type="reset"], .govuk .button-secondary[type="button"] {
-  filter: chroma(color=black);
-}
-/* line 138, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type=submit].button {
-  filter: none;
+/* line 28, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:focus {
+  outline: 3px solid #ffbf47;
 }
 /* line 1, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_colours.scss */
 .govuk .text-secondary {

--- a/assets/stylesheets/example-typography/example-typography-ie8.css
+++ b/assets/stylesheets/example-typography/example-typography-ie8.css
@@ -502,18 +502,21 @@ Example usage:
 .govuk .button-link {
   background: none;
   border: none;
-  line-height: 1.25;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
   color: #005ea5;
+  line-height: 1.25;
   text-decoration: underline;
   cursor: pointer;
+  margin: 0 15px 15px 0;
   padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
-/* line 25, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+/* line 27, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
 .govuk .button-link:hover {
   color: #2e8aca;
 }
-/* line 28, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+/* line 30, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
 .govuk .button-link:focus {
   outline: 3px solid #ffbf47;
 }

--- a/assets/stylesheets/example-typography/example-typography-ie8.css
+++ b/assets/stylesheets/example-typography/example-typography-ie8.css
@@ -422,6 +422,7 @@ Example usage:
   cursor: pointer;
   color: white;
   margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
 /* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
@@ -494,96 +495,30 @@ Example usage:
   filter: none;
 }
 /* line 7, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
-.govuk .button-secondary {
-  background-color: #dee0e2;
-  position: relative;
-  display: -moz-inline-stack;
-  display: inline-block;
-  padding: 0.35em 0.5em 0.15em 0.5em;
+.govuk .button:focus {
+  outline: 3px solid #ffbf47;
+}
+/* line 11, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link {
+  background: none;
   border: none;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-  border-radius: 0;
-  -webkit-appearance: none;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-  font-size: 1em;
-  line-height: 1.25;
-  text-decoration: none;
   -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  color: #005ea5;
+  line-height: 1.25;
+  text-decoration: underline;
   cursor: pointer;
-  color: #0b0c0c;
+  margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top;
 }
-/* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:visited {
-  background-color: #dee0e2;
+/* line 27, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:hover {
+  color: #2e8aca;
 }
-/* line 55, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus {
-  background-color: #d0d3d6;
-}
-/* line 58, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active {
-  top: 2px;
-  -webkit-box-shadow: 0 0 0 #dee0e2;
-  -moz-box-shadow: 0 0 0 #dee0e2;
-  box-shadow: 0 0 0 #dee0e2;
-}
-/* line 66, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled, .govuk .button-secondary[disabled="disabled"], .govuk .button-secondary[disabled] {
-  zoom: 1;
-  filter: alpha(opacity=50);
-  opacity: 0.5;
-}
-/* line 68, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:hover, .govuk .button-secondary[disabled="disabled"]:hover, .govuk .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 72, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:active, .govuk .button-secondary[disabled="disabled"]:active, .govuk .button-secondary[disabled]:active {
-  top: 0;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  border-bottom: 2px solid #b5babe;
-}
-/* line 93, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus, .govuk .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 100, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:before {
-  content: "";
-  height: 110%;
-  width: 100%;
-  display: block;
-  background: transparent;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-/* line 110, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-}
-/* line 123, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[rel="external"]:after {
-  display: none;
-  content: none;
-  margin-left: 0;
-  margin-right: 0;
-}
-/* line 134, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type="submit"], .govuk .button-secondary[type="reset"], .govuk .button-secondary[type="button"] {
-  filter: chroma(color=black);
-}
-/* line 138, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[type=submit].button {
-  filter: none;
+/* line 30, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:focus {
+  outline: 3px solid #ffbf47;
 }
 /* line 1, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_colours.scss */
 .govuk .text-secondary {

--- a/assets/stylesheets/example-typography/example-typography.css
+++ b/assets/stylesheets/example-typography/example-typography.css
@@ -544,18 +544,21 @@ Example usage:
 .govuk .button-link {
   background: none;
   border: none;
-  line-height: 1.25;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
   color: #005ea5;
+  line-height: 1.25;
   text-decoration: underline;
   cursor: pointer;
+  margin: 0 15px 15px 0;
   padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
-/* line 25, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+/* line 27, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
 .govuk .button-link:hover {
   color: #2e8aca;
 }
-/* line 28, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+/* line 30, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
 .govuk .button-link:focus {
   outline: 3px solid #ffbf47;
 }

--- a/assets/stylesheets/example-typography/example-typography.css
+++ b/assets/stylesheets/example-typography/example-typography.css
@@ -473,6 +473,7 @@ Example usage:
   cursor: pointer;
   color: white;
   margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
 /* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
@@ -536,86 +537,27 @@ Example usage:
   margin-right: 0;
 }
 /* line 7, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
-.govuk .button-secondary {
-  background-color: #dee0e2;
-  position: relative;
-  display: -moz-inline-stack;
-  display: inline-block;
-  padding: 0.35em 0.5em 0.15em 0.5em;
+.govuk .button:focus {
+  outline: 3px solid #ffbf47;
+}
+/* line 11, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link {
+  background: none;
   border: none;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-  border-radius: 0;
-  -webkit-appearance: none;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  font-size: 1em;
   line-height: 1.25;
-  text-decoration: none;
-  -webkit-font-smoothing: antialiased;
+  color: #005ea5;
+  text-decoration: underline;
   cursor: pointer;
-  color: #0b0c0c;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top;
 }
-/* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:visited {
-  background-color: #dee0e2;
+/* line 25, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:hover {
+  color: #2e8aca;
 }
-/* line 55, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus {
-  background-color: #d0d3d6;
-}
-/* line 58, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active {
-  top: 2px;
-  -webkit-box-shadow: 0 0 0 #dee0e2;
-  -moz-box-shadow: 0 0 0 #dee0e2;
-  box-shadow: 0 0 0 #dee0e2;
-}
-/* line 66, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled, .govuk .button-secondary[disabled="disabled"], .govuk .button-secondary[disabled] {
-  zoom: 1;
-  filter: alpha(opacity=50);
-  opacity: 0.5;
-}
-/* line 68, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:hover, .govuk .button-secondary[disabled="disabled"]:hover, .govuk .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 72, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:active, .govuk .button-secondary[disabled="disabled"]:active, .govuk .button-secondary[disabled]:active {
-  top: 0;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-}
-/* line 93, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus, .govuk .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 100, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:before {
-  content: "";
-  height: 110%;
-  width: 100%;
-  display: block;
-  background: transparent;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-/* line 110, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-}
-/* line 123, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[rel="external"]:after {
-  display: none;
-  content: none;
-  margin-left: 0;
-  margin-right: 0;
+/* line 28, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:focus {
+  outline: 3px solid #ffbf47;
 }
 /* line 1, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_colours.scss */
 .govuk .text-secondary {

--- a/assets/stylesheets/example-typography/example-typography.css
+++ b/assets/stylesheets/example-typography/example-typography.css
@@ -473,6 +473,7 @@ Example usage:
   cursor: pointer;
   color: white;
   margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
   vertical-align: top;
 }
 /* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
@@ -536,86 +537,30 @@ Example usage:
   margin-right: 0;
 }
 /* line 7, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
-.govuk .button-secondary {
-  background-color: #dee0e2;
-  position: relative;
-  display: -moz-inline-stack;
-  display: inline-block;
-  padding: 0.35em 0.5em 0.15em 0.5em;
+.govuk .button:focus {
+  outline: 3px solid #ffbf47;
+}
+/* line 11, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link {
+  background: none;
   border: none;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-  border-radius: 0;
-  -webkit-appearance: none;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-  font-size: 1em;
-  line-height: 1.25;
-  text-decoration: none;
   -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  color: #005ea5;
+  line-height: 1.25;
+  text-decoration: underline;
   cursor: pointer;
-  color: #0b0c0c;
+  margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top;
 }
-/* line 51, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:visited {
-  background-color: #dee0e2;
+/* line 27, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:hover {
+  color: #2e8aca;
 }
-/* line 55, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus {
-  background-color: #d0d3d6;
-}
-/* line 58, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active {
-  top: 2px;
-  -webkit-box-shadow: 0 0 0 #dee0e2;
-  -moz-box-shadow: 0 0 0 #dee0e2;
-  box-shadow: 0 0 0 #dee0e2;
-}
-/* line 66, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled, .govuk .button-secondary[disabled="disabled"], .govuk .button-secondary[disabled] {
-  zoom: 1;
-  filter: alpha(opacity=50);
-  opacity: 0.5;
-}
-/* line 68, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:hover, .govuk .button-secondary[disabled="disabled"]:hover, .govuk .button-secondary[disabled]:hover {
-  cursor: default;
-  background-color: #dee0e2;
-}
-/* line 72, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary.disabled:active, .govuk .button-secondary[disabled="disabled"]:active, .govuk .button-secondary[disabled]:active {
-  top: 0;
-  -webkit-box-shadow: 0 2px 0 #b5babe;
-  -moz-box-shadow: 0 2px 0 #b5babe;
-  box-shadow: 0 2px 0 #b5babe;
-}
-/* line 93, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:hover, .govuk .button-secondary:focus, .govuk .button-secondary:visited {
-  color: #0b0c0c;
-}
-/* line 100, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:before {
-  content: "";
-  height: 110%;
-  width: 100%;
-  display: block;
-  background: transparent;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-/* line 110, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary:active:before {
-  top: -10%;
-  height: 120%;
-}
-/* line 123, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
-.govuk .button-secondary[rel="external"]:after {
-  display: none;
-  content: none;
-  margin-left: 0;
-  margin-right: 0;
+/* line 30, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_buttons.scss */
+.govuk .button-link:focus {
+  outline: 3px solid #ffbf47;
 }
 /* line 1, /Users/gemmaleigh/Sites/govuk/design-patterns/assets/sass/govuk-helper/_colours.scss */
 .govuk .text-secondary {

--- a/example/form.md
+++ b/example/form.md
@@ -58,7 +58,7 @@ breadcrumb:
           
           <div class="form-group">
             <input type="submit" class="button" value="Next">
-            <button class="button-secondary">Back</button>
+            <button class="button-link">Back</button>
           </div>
           
         </fieldset>

--- a/guides/design-style-guide.md
+++ b/guides/design-style-guide.md
@@ -388,6 +388,7 @@ breadcrumb:
   <div class="inner-block">
     <button class="button">Primary button</button>
     <button class="button-link">Secondary button</button>
+    <a class="button-link" href="{{ site.baseurl}}/example/form.html">Link</a>
   </div>
 </div>
 

--- a/guides/design-style-guide.md
+++ b/guides/design-style-guide.md
@@ -367,10 +367,19 @@ breadcrumb:
 <div class="text">
   <h3 class="heading-24">Buttons</h3>
   <p>
-    Primary actions are green ($green), secondary actions are grey ($grey-3). They use the button mixin defined in the <a href="https://github.com/alphagov/govuk_frontend_toolkit#buttons">GOV.UK front end toolkit</a>. 
+     Buttons use the button mixin defined in the <a href="https://github.com/alphagov/govuk_frontend_toolkit#buttons">GOV.UK front end toolkit</a>. 
+  </p>
+  <h4 class="heading-19">Changing the secondary grey button style</h4>
+  <p>
+    The grey button has a couple of issues - when positioned next to our primary green button some users assume that the grey means the button is disabled. 
+
+    To others, it looks more like a default OS button than the green one, which can be confusing.
   </p>
   <p>
-    The button text colour is set by the mixin to either light or dark, depending on the button background colour.
+    To remove this confusion, we're changing the grey button to look like a link, but with appropriate whitespace so that it can be positioned consistently alongside the primary green buttons.
+  </p>
+  <p>
+    Yellow focus states for all buttons are also shown.
   </p>
 </div>
 
@@ -378,7 +387,8 @@ breadcrumb:
 <div class="example">
   <div class="inner-block">
     <button class="button">Primary button</button>
-    <button class="button-secondary">Secondary button</button>
+    <button class="button-link">Secondary button</button>
+    <a class="button-link" href="{{ site.baseurl}}/example/form.html">Link</a>
   </div>
 </div>
 

--- a/guides/design-style-guide.md
+++ b/guides/design-style-guide.md
@@ -367,10 +367,19 @@ breadcrumb:
 <div class="text">
   <h3 class="heading-24">Buttons</h3>
   <p>
-    Primary actions are green ($green), secondary actions are grey ($grey-3). They use the button mixin defined in the <a href="https://github.com/alphagov/govuk_frontend_toolkit#buttons">GOV.UK front end toolkit</a>. 
+     Buttons use the button mixin defined in the <a href="https://github.com/alphagov/govuk_frontend_toolkit#buttons">GOV.UK front end toolkit</a>. 
+  </p>
+  <h4 class="heading-19">Changing the secondary grey button style</h4>
+  <p>
+    The grey button has a couple of issues - when positioned next to our primary green button some users assume that the grey means the button is disabled. 
+
+    To others, it looks more like a default OS button than the green one, which can be confusing.
   </p>
   <p>
-    The button text colour is set by the mixin to either light or dark, depending on the button background colour.
+    To remove this confusion, we're changing the grey button to look like a link, but with appropriate whitespace so that it can be positioned consistently alongside the primary green buttons.
+  </p>
+  <p>
+    Yellow focus states for all buttons are also shown.
   </p>
 </div>
 
@@ -378,7 +387,7 @@ breadcrumb:
 <div class="example">
   <div class="inner-block">
     <button class="button">Primary button</button>
-    <button class="button-secondary">Secondary button</button>
+    <button class="button-link">Secondary button</button>
   </div>
 </div>
 


### PR DESCRIPTION
- Add new ‘button-link’ style
- Remove ‘button-secondary’ style
- Update Design Style Guide with secondary button guidance, why to use
  button-link instead
